### PR TITLE
BUG/COMPAT: fix autoplot label issue caused by dplyr spec change

### DIFF
--- a/R/base_fortify_ts.R
+++ b/R/base_fortify_ts.R
@@ -12,14 +12,14 @@
 #' @param ... other arguments passed to methods
 #' @return data.frame
 #' @examples
-#' ggplot2::fortify(AirPassengers)
-#' ggplot2::fortify(timeSeries::as.timeSeries(AirPassengers))
+#' fortify(AirPassengers)
+#' fortify(timeSeries::as.timeSeries(AirPassengers))
 #'
 #' its <- tseries::irts(cumsum(rexp(10, rate = 0.1)), matrix(rnorm(20), ncol=2))
-#' ggplot2::fortify(its)
+#' fortify(its)
 #'
-#' ggplot2::fortify(stats::stl(UKgas, s.window = 'periodic'))
-#' ggplot2::fortify(stats::decompose(UKgas))
+#' fortify(stats::stl(UKgas, s.window = 'periodic'))
+#' fortify(stats::decompose(UKgas))
 #' @export
 fortify.ts <- function(model, data = NULL, columns = NULL, is.date = NULL,
                        index.name = 'Index', data.name = 'Data',
@@ -46,7 +46,11 @@ fortify.ts <- function(model, data = NULL, columns = NULL, is.date = NULL,
     } else if (is(model, 'decomposed.ts')) {
       dtindex <- get.dtindex(model$x, is.date = is.date)
       dtframe <- ggplot2::fortify(model$x)
-      dtframe <- dtframe[, -1]
+
+      # for tbl_df
+      # dtframe <- dtframe[, -1]
+      dtframe <- data.frame(Data = dtframe[['Data']])
+
       # trend and random can be multivariate
       rndframe <- model$random
       colnames(rndframe) <- NULL
@@ -83,7 +87,7 @@ fortify.ts <- function(model, data = NULL, columns = NULL, is.date = NULL,
   if (melt) {
     d <- tidyr::gather_(d, 'variable', 'value', columns)
   }
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' @export
@@ -117,25 +121,25 @@ fortify.irts <- fortify.ts
 #' @aliases autoplot.xts autoplot.timeSeries autoplot.irts autoplot.stl autoplot.decomposed.ts
 #' @examples
 #' data(Canada, package = 'vars')
-#' ggplot2::autoplot(AirPassengers)
-#' ggplot2::autoplot(UKgas, ts.geom = 'bar')
-#' ggplot2::autoplot(Canada)
-#' ggplot2::autoplot(Canada, columns = 'e', is.date = TRUE)
-#' ggplot2::autoplot(Canada, facets = FALSE)
+#' autoplot(AirPassengers)
+#' autoplot(UKgas, ts.geom = 'bar')
+#' autoplot(Canada)
+#' autoplot(Canada, columns = 'e', is.date = TRUE)
+#' autoplot(Canada, facets = FALSE)
 #'
 #' library(zoo)
-#' ggplot2::autoplot(xts::as.xts(AirPassengers))
-#' ggplot2::autoplot(xts::as.xts(UKgas))
-#' ggplot2::autoplot(xts::as.xts(Canada))
+#' autoplot(xts::as.xts(AirPassengers))
+#' autoplot(xts::as.xts(UKgas))
+#' autoplot(xts::as.xts(Canada))
 #'
-#' ggplot2::autoplot(timeSeries::as.timeSeries(AirPassengers))
-#' ggplot2::autoplot(timeSeries::as.timeSeries(Canada))
+#' autoplot(timeSeries::as.timeSeries(AirPassengers))
+#' autoplot(timeSeries::as.timeSeries(Canada))
 #'
 #' its <- tseries::irts(cumsum(rexp(10, rate = 0.1)), matrix(rnorm(20), ncol=2))
-#' ggplot2::autoplot(its)
+#' autoplot(its)
 #'
-#' ggplot2::autoplot(stats::stl(UKgas, s.window = 'periodic'))
-#' ggplot2::autoplot(stats::decompose(UKgas))
+#' autoplot(stats::stl(UKgas, s.window = 'periodic'))
+#' autoplot(stats::decompose(UKgas))
 #' @export
 autoplot.ts <- function(object, columns = NULL, group = NULL,
                         is.date = NULL, index.name = 'Index',
@@ -248,18 +252,18 @@ autoplot.irts <- autoplot.ts
 #' @aliases fortify.ar fortify.Arima fortify.fracdiff
 #' fortify.nnetar fortify.HoltWinters fortify.fGARCH
 #' @examples
-#' ggplot2::fortify(stats::ar(AirPassengers))
-#' ggplot2::fortify(stats::arima(UKgas))
-#' ggplot2::fortify(stats::arima(UKgas), data = UKgas, is.date = TRUE)
-#' ggplot2::fortify(forecast::auto.arima(austres))
-#' ggplot2::fortify(forecast::arfima(AirPassengers))
-#' ggplot2::fortify(forecast::nnetar(UKgas))
-#' ggplot2::fortify(stats::HoltWinters(USAccDeaths))
+#' fortify(stats::ar(AirPassengers))
+#' fortify(stats::arima(UKgas))
+#' fortify(stats::arima(UKgas), data = UKgas, is.date = TRUE)
+#' fortify(forecast::auto.arima(austres))
+#' fortify(forecast::arfima(AirPassengers))
+#' fortify(forecast::nnetar(UKgas))
+#' fortify(stats::HoltWinters(USAccDeaths))
 #'
 #' data(LPP2005REC, package = 'timeSeries')
 #' x = timeSeries::as.timeSeries(LPP2005REC)
 #' d.Garch = fGarch::garchFit(LPP40 ~ garch(1, 1), data = 100 * x, trace = FALSE)
-#' ggplot2::fortify(d.Garch)
+#' fortify(d.Garch)
 fortify.tsmodel <- function(model, data = NULL, original = NULL,
                             predict = NULL,
                             is.date = NULL,
@@ -345,7 +349,7 @@ fortify.tsmodel <- function(model, data = NULL, original = NULL,
     n <- nrow(d)
     d <- rbind_ts(pred, d, ts.connect = ts.connect)
   }
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' @export
@@ -399,24 +403,24 @@ fortify.KFS <- fortify.tsmodel
 #' @aliases autoplot.ar autoplot.fracdiff autoplot.nnetar autoplot.HoltWinters autoplot.fGARCH
 #' @examples
 #' d.ar <- stats::ar(AirPassengers)
-#' ggplot2::autoplot(d.ar)
-#' ggplot2::autoplot(d.ar, predict = predict(d.ar, n.ahead = 5))
-#' ggplot2::autoplot(stats::arima(UKgas), data = UKgas)
-#' ggplot2::autoplot(forecast::arfima(AirPassengers))
-#' ggplot2::autoplot(forecast::nnetar(UKgas), is.date = FALSE)
+#' autoplot(d.ar)
+#' autoplot(d.ar, predict = predict(d.ar, n.ahead = 5))
+#' autoplot(stats::arima(UKgas), data = UKgas)
+#' autoplot(forecast::arfima(AirPassengers))
+#' autoplot(forecast::nnetar(UKgas), is.date = FALSE)
 #'
 #' d.holt <- stats::HoltWinters(USAccDeaths)
-#' ggplot2::autoplot(d.holt)
-#' ggplot2::autoplot(d.holt, predict = predict(d.holt, n.ahead = 5))
-#' ggplot2::autoplot(d.holt, predict = predict(d.holt, n.ahead = 5, prediction.interval = TRUE))
+#' autoplot(d.holt)
+#' autoplot(d.holt, predict = predict(d.holt, n.ahead = 5))
+#' autoplot(d.holt, predict = predict(d.holt, n.ahead = 5, prediction.interval = TRUE))
 #'
 #' form <- function(theta){
 #'   dlm::dlmModPoly(order=1, dV=exp(theta[1]), dW=exp(theta[2]))
 #' }
 #' model <- form(dlm::dlmMLE(Nile, parm=c(1, 1), form)$par)
 #' filtered <- dlm::dlmFilter(Nile, model)
-#' ggplot2::autoplot(filtered)
-#' ggplot2::autoplot(dlm::dlmSmooth(filtered))
+#' autoplot(filtered)
+#' autoplot(dlm::dlmSmooth(filtered))
 #' @export
 autoplot.tsmodel <- function(object, data = NULL, original = NULL,
                              predict = NULL,

--- a/R/fortify_MSwM.R
+++ b/R/fortify_MSwM.R
@@ -11,7 +11,7 @@
 #'                 exog = cos(seq(-pi/2, pi/2, length.out = 100)))
 #' d.mswm <- MSwM::msmFit(lm(Data ~.-1, data = d), k=2, sw=rep(TRUE, 2),
 #'                        control = list(parallelization = FALSE))
-#' ggplot2::fortify(d.mswm)
+#' fortify(d.mswm)
 #' @export
 fortify.MSM.lm <- function(model, data = NULL, melt = FALSE, ...) {
   probable <- apply(model@Fit@smoProb[-1, ], 1, which.max)
@@ -42,7 +42,7 @@ fortify.MSM.lm <- function(model, data = NULL, melt = FALSE, ...) {
                           SmoProb = model@Fit@smoProb[-1, ],
                           ProbableModel = probable))
   }
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' Autoplot \code{MSwM::MSM.lm}.
@@ -58,7 +58,7 @@ fortify.MSM.lm <- function(model, data = NULL, melt = FALSE, ...) {
 #'                 exog = cos(seq(-pi/2, pi/2, length.out = 100)))
 #' d.mswm <- MSwM::msmFit(lm(Data ~.-1, data = d), k=2, sw=rep(TRUE, 2),
 #'                        control = list(parallelization = FALSE))
-#' ggplot2::autoplot(d.mswm)
+#' autoplot(d.mswm)
 #' @export
 autoplot.MSM.lm <- function(object, prob.colour = '#FF0000',
                             prob.linetype = 'dashed', ...) {

--- a/R/fortify_base.R
+++ b/R/fortify_base.R
@@ -5,10 +5,10 @@
 #' @param ... other arguments passed to methods
 #' @return data.frame
 #' @examples
-#' ggplot2::fortify(Titanic)
+#' fortify(Titanic)
 #' @export
 fortify.table <- function(model, data, ...) {
-  dplyr::tbl_df(as.data.frame(model))
+  as.data.frame(model)
 }
 
 #' Convert \code{base::matrix} to data.frame.
@@ -23,17 +23,17 @@ fortify.table <- function(model, data, ...) {
 #' @param ... other arguments passed to methods
 #' @return data.frame
 #' @examples
-#' ggplot2::fortify(matrix(1:6, nrow=2, ncol=3))
+#' fortify(matrix(1:6, nrow=2, ncol=3))
 #' @export
 fortify.matrix <- function(model, data = NULL, compat = FALSE, ...) {
-  df <- as.data.frame(model)
+  d <- as.data.frame(model)
   if ((!compat) && is.null(colnames(model))) {
     # set numeric column names
-    colnames(df) <- 1:ncol(model)
+    colnames(d) <- 1:ncol(model)
   }
   # dplyr doesn't guarantee rownames
-  df <- cbind_wraps(df, data)
-  df <- dplyr::tbl_df(df)
+  d <- cbind_wraps(d, data)
+  post.fortify(d)
 }
 
 #' Plot \code{base::matrix}
@@ -51,11 +51,11 @@ fortify.matrix <- function(model, data = NULL, compat = FALSE, ...) {
 #' @param ... other arguments passed to methods
 #' @return ggplot
 #' @examples
-#' ggplot2::autoplot(matrix(rnorm(20), nc = 5))
-#' ggplot2::autoplot(matrix(rnorm(20), nc = 5), fill = 'red')
-#' ggplot2::autoplot(matrix(rnorm(20), nc = 5),
-#'                   scale = ggplot2::scale_fill_gradient(low = 'red', high = 'blue'))
-#' ggplot2::autoplot(matrix(rnorm(20), nc = 2), geom = 'point')
+#' autoplot(matrix(rnorm(20), nc = 5))
+#' autoplot(matrix(rnorm(20), nc = 5), fill = 'red')
+#' autoplot(matrix(rnorm(20), nc = 5),
+#'          scale = scale_fill_gradient(low = 'red', high = 'blue'))
+#' autoplot(matrix(rnorm(20), nc = 2), geom = 'point')
 #' @export
 autoplot.matrix <- function (object, original = NULL,
                              fill = '#0000FF', scale = NULL,
@@ -63,10 +63,11 @@ autoplot.matrix <- function (object, original = NULL,
                              label = FALSE, label.colour = colour, label.size = 4,
                              geom = 'tile', ...) {
   if (geom == 'tile') {
-    df <- ggplot2::fortify(object, original = original)
-    df$Index <- rownames(df)
-    cols <- colnames(df)
-    gathered <- tidyr::gather_(df, 'variable', 'value', cols[cols != 'Index'])
+    fortified <- ggplot2::fortify(object, original = original)
+    fortified$Index <- rownames(fortified)
+    cols <- colnames(fortified)
+    gathered <- tidyr::gather_(fortified, 'variable', 'value',
+                               cols[cols != 'Index'])
 
     if (is.null(scale)) {
       scale <- ggplot2::scale_fill_gradient(low = "white", high = fill)

--- a/R/fortify_changepoint.R
+++ b/R/fortify_changepoint.R
@@ -10,15 +10,15 @@
 #' @aliases fortify.breakpointsfull fortify.breakpoints
 #' @examples
 #' library(changepoint)
-#' ggplot2::fortify(cpt.mean(AirPassengers))
-#' ggplot2::fortify(cpt.var(AirPassengers))
-#' ggplot2::fortify(cpt.meanvar(AirPassengers))
+#' fortify(cpt.mean(AirPassengers))
+#' fortify(cpt.var(AirPassengers))
+#' fortify(cpt.meanvar(AirPassengers))
 #'
 #' library(strucchange)
 #' bp.nile <- breakpoints(Nile ~ 1)
-#' ggplot2::fortify(bp.nile)
-#' ggplot2::fortify(breakpoints(bp.nile, breaks = 2))
-#' ggplot2::fortify(breakpoints(bp.nile, breaks = 2), data = Nile)
+#' fortify(bp.nile)
+#' fortify(breakpoints(bp.nile, breaks = 2))
+#' fortify(breakpoints(bp.nile, breaks = 2), data = Nile)
 #' @export
 fortify.cpt <- function(model, data = NULL, original = NULL,
                         is.date = NULL, ...) {
@@ -57,7 +57,7 @@ fortify.cpt <- function(model, data = NULL, original = NULL,
   } else {
     stop(paste0('Unsupported class for autoplot.pca_common: ', class(model)))
   }
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' @export
@@ -77,8 +77,8 @@ fortify.breakpointsfull <- fortify.cpt
 #' @return ggplot
 #' @examples
 #' library(changepoint)
-#' ggplot2::autoplot(cpt.mean(AirPassengers))
-#' ggplot2::autoplot(cpt.meanvar(AirPassengers))
+#' autoplot(cpt.mean(AirPassengers))
+#' autoplot(cpt.meanvar(AirPassengers))
 #' @export
 autoplot.cpt <- function(object, is.date = NULL,
                          cpt.colour = '#FF0000', cpt.linetype = 'dashed',
@@ -113,9 +113,9 @@ autoplot.cpt <- function(object, is.date = NULL,
 #' @examples
 #' library(strucchange)
 #' bp.nile <- breakpoints(Nile ~ 1)
-#' ggplot2::autoplot(bp.nile)
-#' ggplot2::autoplot(bp.nile, is.date = TRUE)
-#' ggplot2::autoplot(breakpoints(bp.nile, breaks = 2), data = Nile)
+#' autoplot(bp.nile)
+#' autoplot(bp.nile, is.date = TRUE)
+#' autoplot(breakpoints(bp.nile, breaks = 2), data = Nile)
 #' @export
 autoplot.breakpoints <- function(object, data = NULL, original = NULL,
                                  cpt.colour = '#FF0000', cpt.linetype = 'dashed',

--- a/R/fortify_cluster.R
+++ b/R/fortify_cluster.R
@@ -7,12 +7,11 @@
 #' @param ... other arguments passed to methods
 #' @return data.frame
 #' @examples
-#' df <- iris[-5]
-#' ggplot2::fortify(stats::kmeans(df, 3))
-#' ggplot2::fortify(stats::kmeans(df, 3), data = iris)
-#' ggplot2::fortify(cluster::clara(df, 3))
-#' ggplot2::fortify(cluster::fanny(df, 3))
-#' ggplot2::fortify(cluster::pam(df, 3), data = iris)
+#' fortify(stats::kmeans(iris[-5], 3))
+#' fortify(stats::kmeans(iris[-5], 3), data = iris)
+#' fortify(cluster::clara(iris[-5], 3))
+#' fortify(cluster::fanny(iris[-5], 3))
+#' fortify(cluster::pam(iris[-5], 3), data = iris)
 #' @export
 fortify.kmeans <- function(model, data = NULL, original = NULL, ...) {
 
@@ -24,13 +23,13 @@ fortify.kmeans <- function(model, data = NULL, original = NULL, ...) {
   if (is(model, 'kmeans')) {
     d <- data.frame(cluster = as.factor(model$cluster))
   } else if (is(model, 'partition')) {
-    d <- data.frame(cluster = as.factor(model$cluster),
-                    ggplot2::fortify(model$data))
+    d <- data.frame(ggplot2::fortify(model$data),
+                    cluster = as.factor(model$cluster))
   } else {
     stop(paste0('Unsupported class for fortify.kmeans: ', class(model)))
   }
-  d <- cbind_wraps(d, data)
-  dplyr::tbl_df(d)
+  d <- cbind_wraps(data, d)
+  post.fortify(d)
 }
 
 
@@ -43,13 +42,12 @@ fortify.kmeans <- function(model, data = NULL, original = NULL, ...) {
 #' @param ... other arguments passed to \code{autoplot::prcomp}
 #' @return ggplot
 #' @examples
-#' df <- iris[-5]
-#' ggplot2::autoplot(stats::kmeans(df, 3), data = iris)
-#' ggplot2::autoplot(cluster::clara(df, 3), label = TRUE)
-#' ggplot2::autoplot(cluster::fanny(df, 3))
-#' ggplot2::autoplot(cluster::fanny(df, 3), frame = TRUE)
-#' ggplot2::autoplot(cluster::pam(df, 3), data = iris)
-#' ggplot2::autoplot(cluster::pam(df, 3), data = iris, frame = TRUE, frame.type = 't')
+#' autoplot(stats::kmeans(iris[-5], 3), data = iris)
+#' autoplot(cluster::clara(iris[-5], 3), label = TRUE)
+#' autoplot(cluster::fanny(iris[-5], 3))
+#' autoplot(cluster::fanny(iris[-5], 3), frame = TRUE)
+#' autoplot(cluster::pam(iris[-5], 3), data = iris)
+#' autoplot(cluster::pam(iris[-5], 3), data = iris, frame = TRUE, frame.type = 't')
 #' @export
 autoplot.kmeans <- function(object, data = NULL, original = NULL, ...) {
 

--- a/R/fortify_forecast.R
+++ b/R/fortify_forecast.R
@@ -11,8 +11,8 @@
 #' @examples
 #' d.arima <- forecast::auto.arima(AirPassengers)
 #' d.forecast <- forecast::forecast(d.arima, level = c(95), h = 50)
-#' ggplot2::fortify(d.forecast)
-#' ggplot2::fortify(d.forecast, ts.connect = TRUE)
+#' fortify(d.forecast)
+#' fortify(d.forecast, ts.connect = TRUE)
 fortify.forecast <- function(model, data = NULL, is.date = NULL,
                              ts.connect = FALSE, ...) {
   forecasted <- as.data.frame(model)
@@ -22,7 +22,7 @@ fortify.forecast <- function(model, data = NULL, is.date = NULL,
   fitted <- ggplot2::fortify(model$fitted, data.name = 'Fitted', is.date = is.date)
   d <- dplyr::left_join(d, fitted, by = 'Index')
   d <- ggfortify::rbind_ts(forecasted, d, ts.connect = ts.connect)
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' Autoplot \code{forecast::forecast}.
@@ -42,12 +42,12 @@ fortify.forecast <- function(model, data = NULL, is.date = NULL,
 #' @return ggplot
 #' @examples
 #' d.arima <- forecast::auto.arima(AirPassengers)
-#' ggplot2::autoplot(forecast::forecast(d.arima, h = 10))
-#' ggplot2::autoplot(forecast::forecast(d.arima, level = c(85), h = 10))
-#' ggplot2::autoplot(forecast::forecast(d.arima, h = 5), conf.int = FALSE)
-#' ggplot2::autoplot(forecast::forecast(d.arima, h = 10), is.date = FALSE)
-#' ggplot2::autoplot(forecast::forecast(forecast::ets(UKgas), h = 5))
-#' ggplot2::autoplot(forecast::forecast(stats::HoltWinters(UKgas), h = 10))
+#' autoplot(forecast::forecast(d.arima, h = 10))
+#' autoplot(forecast::forecast(d.arima, level = c(85), h = 10))
+#' autoplot(forecast::forecast(d.arima, h = 5), conf.int = FALSE)
+#' autoplot(forecast::forecast(d.arima, h = 10), is.date = FALSE)
+#' autoplot(forecast::forecast(forecast::ets(UKgas), h = 5))
+#' autoplot(forecast::forecast(stats::HoltWinters(UKgas), h = 10))
 #' @export
 autoplot.forecast <- function(object, is.date = NULL, ts.connect = TRUE,
                               predict.colour = '#0000FF', predict.linetype = 'solid',
@@ -90,8 +90,8 @@ autoplot.forecast <- function(object, is.date = NULL, ts.connect = TRUE,
 #' @param ... other arguments passed to methods
 #' @return data.frame
 #' @examples
-#' ggplot2::fortify(forecast::bats(UKgas))
-#' ggplot2::fortify(forecast::ets(UKgas))
+#' fortify(forecast::bats(UKgas))
+#' fortify(forecast::ets(UKgas))
 #' @export
 fortify.ets <- function(model, data = NULL, ...) {
   if (is(model, 'ets')) {
@@ -137,7 +137,7 @@ fortify.ets <- function(model, data = NULL, ...) {
   } else {
     stop(paste0('Unsupported class for fortify.ets: ', class(model)))
   }
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' @export
@@ -152,9 +152,9 @@ fortify.bats <- fortify.ets
 #' @aliases autoplot.bats
 #' @examples
 #' d.bats <- forecast::bats(UKgas)
-#' ggplot2::autoplot(d.bats)
-#' ggplot2::autoplot(d.bats, columns = 'Residuals')
-#' ggplot2::autoplot(forecast::ets(UKgas))
+#' autoplot(d.bats)
+#' autoplot(d.bats, columns = 'Residuals')
+#' autoplot(forecast::ets(UKgas))
 #' @export
 autoplot.ets <- function(object, columns = NULL, ...) {
   plot.data <- ggplot2::fortify(object)

--- a/R/fortify_stats.R
+++ b/R/fortify_stats.R
@@ -2,7 +2,7 @@
 fortify.stl <- fortify.ts
 
 #' @export
-fortify.decomposed.ts <- fortify.stl
+fortify.decomposed.ts <- fortify.ts
 
 #' @export
 autoplot.stl <- autoplot.ts
@@ -20,11 +20,11 @@ autoplot.decomposed.ts <- autoplot.ts
 #' @param ... other arguments passed to methods
 #' @return data.frame
 #' @examples
-#' ggplot2::fortify(stats::acf(AirPassengers))
-#' ggplot2::fortify(stats::pacf(AirPassengers))
-#' ggplot2::fortify(stats::ccf(AirPassengers, AirPassengers))
+#' fortify(stats::acf(AirPassengers))
+#' fortify(stats::pacf(AirPassengers))
+#' fortify(stats::ccf(AirPassengers, AirPassengers))
 #'
-#' ggplot2::fortify(stats::acf(AirPassengers), conf.int = TRUE)
+#' fortify(stats::acf(AirPassengers), conf.int = TRUE)
 #' @export
 fortify.acf <- function(model, data = NULL,
                         conf.int = TRUE, conf.int.value = 0.95,
@@ -35,7 +35,7 @@ fortify.acf <- function(model, data = NULL,
     cfd <- data.frame(lower = -cf, upper = cf)
     d <- cbind(d, cfd)
   }
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' Autoplot \code{stats::acf}.
@@ -53,9 +53,9 @@ fortify.acf <- function(model, data = NULL,
 #' @param ... other arguments passed to methods
 #' @return ggplot
 #' @examples
-#' ggplot2::autoplot(stats::acf(AirPassengers))
-#' ggplot2::autoplot(stats::pacf(AirPassengers))
-#' ggplot2::autoplot(stats::ccf(AirPassengers, AirPassengers))
+#' autoplot(stats::acf(AirPassengers))
+#' autoplot(stats::pacf(AirPassengers))
+#' autoplot(stats::ccf(AirPassengers, AirPassengers))
 #' @export
 autoplot.acf <- function(object,
                          colour = '#000000', linetype = 'solid',
@@ -93,14 +93,14 @@ autoplot.acf <- function(object,
 #' @param ... other arguments passed to methods
 #' @return data.frame
 #' @examples
-#' ggplot2::fortify(spectrum(AirPassengers))
-#' ggplot2::fortify(stats::spec.ar(AirPassengers))
-#' ggplot2::fortify(stats::spec.pgram(AirPassengers))
+#' fortify(spectrum(AirPassengers))
+#' fortify(stats::spec.ar(AirPassengers))
+#' fortify(stats::spec.pgram(AirPassengers))
 #' @export
 fortify.spec <- function(model, data = NULL, ...) {
   d <- data.frame(Frequency = model$freq,
                   Spectrum = model$spec)
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' Autoplot \code{stats::spec}.
@@ -109,8 +109,8 @@ fortify.spec <- function(model, data = NULL, ...) {
 #' @param ... other arguments passed to methods
 #' @return ggplot
 #' @examples
-#' ggplot2::autoplot(stats::spec.ar(AirPassengers))
-#' ggplot2::autoplot(stats::spec.pgram(AirPassengers))
+#' autoplot(stats::spec.ar(AirPassengers))
+#' autoplot(stats::spec.pgram(AirPassengers))
 #' @export
 autoplot.spec <- function(object, ...) {
   plot.data <- ggplot2::fortify(object)
@@ -129,12 +129,11 @@ autoplot.spec <- function(object, ...) {
 #' @return data.frame
 #' @aliases fortify.princomp
 #' @examples
-#' df <- iris[-5]
-#' ggplot2::fortify(stats::prcomp(df))
-#' ggplot2::fortify(stats::prcomp(df), data = iris)
+#' fortify(stats::prcomp(iris[-5]))
+#' fortify(stats::prcomp(iris[-5]), data = iris)
 #'
-#' ggplot2::fortify(stats::princomp(df))
-#' ggplot2::fortify(stats::princomp(df), data = iris)
+#' fortify(stats::princomp(iris[-5]))
+#' fortify(stats::princomp(iris[-5]), data = iris)
 #' @export
 fortify.prcomp <- function(model, data = NULL,
                            original = NULL, ...) {
@@ -155,9 +154,9 @@ fortify.prcomp <- function(model, data = NULL,
 
   values <- ggfortify::unscale(values, center = model$center,
                                scale = model$scale)
-  values <- cbind_wraps(values, data)
+  values <- cbind_wraps(data, values)
   d <- cbind_wraps(values, d)
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' @export
@@ -172,8 +171,8 @@ fortify.princomp <- fortify.prcomp
 #' @return data.frame
 #' @examples
 #' d.factanal <- stats::factanal(state.x77, factors = 3, scores = 'regression')
-#' ggplot2::fortify(d.factanal)
-#' ggplot2::fortify(d.factanal, data = state.x77)
+#' fortify(d.factanal)
+#' fortify(d.factanal, data = state.x77)
 #' @export
 fortify.factanal <- function(model, data = NULL,
                              original = NULL, ...) {
@@ -189,7 +188,7 @@ fortify.factanal <- function(model, data = NULL,
   }
   d <- as.data.frame(model$scores)
   d <- cbind_wraps(data, d)
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' Autoplot PCA-likes.
@@ -216,26 +215,25 @@ fortify.factanal <- function(model, data = NULL,
 #' @return ggplot
 #' @aliases autoplot.prcomp autoplot.princomp autoplot.factanal
 #' @examples
-#' df <- iris[-5]
-#' ggplot2::autoplot(stats::prcomp(df))
-#' ggplot2::autoplot(stats::prcomp(df), data = iris)
-#' ggplot2::autoplot(stats::prcomp(df), data = iris, colour = 'Species')
-#' ggplot2::autoplot(stats::prcomp(df), label = TRUE, loadings = TRUE, loadings.label = TRUE)
-#' ggplot2::autoplot(stats::prcomp(df), frame = TRUE)
-#' ggplot2::autoplot(stats::prcomp(df), data = iris, frame = TRUE,
-#'                   frame.colour = 'Species')
-#' ggplot2::autoplot(stats::prcomp(df), data = iris, frame = TRUE,
-#'                   frame.type = 't', frame.colour = 'Species')
+#' autoplot(stats::prcomp(iris[-5]))
+#' autoplot(stats::prcomp(iris[-5]), data = iris)
+#' autoplot(stats::prcomp(iris[-5]), data = iris, colour = 'Species')
+#' autoplot(stats::prcomp(iris[-5]), label = TRUE, loadings = TRUE, loadings.label = TRUE)
+#' autoplot(stats::prcomp(iris[-5]), frame = TRUE)
+#' autoplot(stats::prcomp(iris[-5]), data = iris, frame = TRUE,
+#'          frame.colour = 'Species')
+#' autoplot(stats::prcomp(iris[-5]), data = iris, frame = TRUE,
+#'          frame.type = 't', frame.colour = 'Species')
 #'
-#' ggplot2::autoplot(stats::princomp(df))
-#' ggplot2::autoplot(stats::princomp(df), data = iris)
-#' ggplot2::autoplot(stats::princomp(df), data = iris, colour = 'Species')
-#' ggplot2::autoplot(stats::princomp(df), label = TRUE, loadings = TRUE, loadings.label = TRUE)
+#' autoplot(stats::princomp(iris[-5]))
+#' autoplot(stats::princomp(iris[-5]), data = iris)
+#' autoplot(stats::princomp(iris[-5]), data = iris, colour = 'Species')
+#' autoplot(stats::princomp(iris[-5]), label = TRUE, loadings = TRUE, loadings.label = TRUE)
 #'
 #' d.factanal <- stats::factanal(state.x77, factors = 3, scores = 'regression')
-#' ggplot2::autoplot(d.factanal)
-#' ggplot2::autoplot(d.factanal, data = state.x77, colour = 'Income')
-#' ggplot2::autoplot(d.factanal, label = TRUE, loadings = TRUE, loadings.label = TRUE)
+#' autoplot(d.factanal)
+#' autoplot(d.factanal, data = state.x77, colour = 'Income')
+#' autoplot(d.factanal, label = TRUE, loadings = TRUE, loadings.label = TRUE)
 autoplot.pca_common <- function(object, data = NULL, original = NULL,
                                 colour = NULL,
                                 label = FALSE, label.colour = colour, label.size = 4,
@@ -341,7 +339,7 @@ autoplot.factanal <- autoplot.pca_common
 #' @param ... other arguments passed to methods
 #' @return data.frame
 #' @examples
-#' ggplot2::fortify(eurodist)
+#' fortify(eurodist)
 #' @export
 fortify.dist <- function(model, data = NULL, ...) {
   model <- as.matrix(model)

--- a/R/fortify_stats_density.R
+++ b/R/fortify_stats_density.R
@@ -5,11 +5,11 @@
 #' @param ... other arguments passed to methods
 #' @return data.frame
 #' @examples
-#' ggplot2::fortify(stats::density(stats::rnorm(1:50)))
+#' fortify(stats::density(stats::rnorm(1:50)))
 #' @export
 fortify.density <- function(model, data = NULL, ...) {
   d <- data.frame(x = model$x, y = model$y)
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' Autoplot \code{stats::density}
@@ -23,7 +23,7 @@ fortify.density <- function(model, data = NULL, ...) {
 #' @param ... other arguments passed to PDC/CDF func
 #' @return ggplot
 #' @examples
-#' ggplot2::autoplot(stats::density(stats::rnorm(1:50)))
+#' autoplot(stats::density(stats::rnorm(1:50)))
 #' @export
 autoplot.density <- function (object, p = NULL,
                               colour = '#000000', linetype = 'solid',

--- a/R/fortify_stats_lm.R
+++ b/R/fortify_stats_lm.R
@@ -17,11 +17,11 @@
 #' @param ... other arguments passed to methods
 #' @return ggplot
 #' @examples
-#' ggplot2::autoplot(lm(Petal.Width ~ Petal.Length, data= iris))
-#' ggplot2::autoplot(glm(Petal.Width ~ Petal.Length, data= iris), which = 1:6)
+#' autoplot(lm(Petal.Width ~ Petal.Length, data= iris))
+#' autoplot(glm(Petal.Width ~ Petal.Length, data= iris), which = 1:6)
 #'
-#' ggplot2::autoplot(lm(Petal.Width~Petal.Length, data = iris)) + ggplot2::theme_bw()
-#' ggplot2::autoplot(lm(Petal.Width~Petal.Length, data = iris)) + ggplot2::scale_colour_brewer()
+#' autoplot(lm(Petal.Width~Petal.Length, data = iris)) + theme_bw()
+#' autoplot(lm(Petal.Width~Petal.Length, data = iris)) + scale_colour_brewer()
 #' @export
 autoplot.lm <- function(object, which=c(1:3, 5),
                         fill = '#444444', colour = '#444444',
@@ -50,6 +50,7 @@ autoplot.lm <- function(object, which=c(1:3, 5),
   n <- nrow(plot.data)
 
   plot.data$.index <- 1:n
+  plot.data$.label <- rownames(plot.data)
   if (show[2L]) {
     ylim <- range(plot.data$.stdresid, na.rm = TRUE)
     ylim[2L] <- ylim[2L] + diff(ylim) * 0.075
@@ -91,7 +92,7 @@ autoplot.lm <- function(object, which=c(1:3, 5),
 
   .decorate.label <- function(p, d) {
     if (label.n > 0) {
-      mapping = ggplot2::aes_string(label = '.index')
+      mapping = ggplot2::aes_string(label = '.label')
       p <- p + ggplot2::geom_text(data = d, mapping = mapping,
                                   colour = label.colour, size = label.size)
     }

--- a/R/fortify_surv.R
+++ b/R/fortify_surv.R
@@ -7,10 +7,10 @@
 #' @aliases fortify.survfit.cox
 #' @examples
 #' d.survfit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
-#' ggplot2::fortify(d.survfit)
+#' fortify(d.survfit)
 #'
 #' d.coxph <- survival::coxph(survival::Surv(time, status) ~ sex, data = survival::lung)
-#' ggplot2::fortify(survival::survfit(d.coxph))
+#' fortify(survival::survfit(d.coxph))
 #' @export
 fortify.survfit <- function(model, data = NULL, ...) {
   d <- data.frame(time = model$time,
@@ -29,7 +29,7 @@ fortify.survfit <- function(model, data = NULL, ...) {
   } else {
     stop(paste0('Unsupported class for fortify.survfit: ', class(model)))
   }
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 #' Autoplot \code{survival::survfit}.
@@ -50,11 +50,11 @@ fortify.survfit <- function(model, data = NULL, ...) {
 #' @aliases autoplot.survfit.cox
 #' @examples
 #' d.survfit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
-#' ggplot2::autoplot(d.survfit)
-#' ggplot2::autoplot(d.survfit, conf.int = FALSE, censor = FALSE)
+#' autoplot(d.survfit)
+#' autoplot(d.survfit, conf.int = FALSE, censor = FALSE)
 #'
 #' d.coxph <- survival::coxph(survival::Surv(time, status) ~ sex, data = survival::lung)
-#' ggplot2::autoplot(survival::survfit(d.coxph))
+#' autoplot(survival::survfit(d.coxph))
 #' @export
 autoplot.survfit <- function(object,
                              surv.colour = '#000000', surv.linetype = 'solid',

--- a/R/fortify_vars.R
+++ b/R/fortify_vars.R
@@ -12,7 +12,7 @@
 #' data(Canada, package = 'vars')
 #' d.vselect <- vars::VARselect(Canada, lag.max = 5, type = 'const')$selection[1]
 #' d.var <- vars::VAR(Canada, p = d.vselect, type = 'const')
-#' ggplot2::fortify(stats::predict(d.var, n.ahead = 50))
+#' fortify(stats::predict(d.var, n.ahead = 50))
 #' @export
 fortify.varprd <- function(model, data = NULL, is.date = NULL,
                            ts.connect = FALSE, melt = FALSE, ...){
@@ -66,8 +66,8 @@ fortify.varprd <- function(model, data = NULL, is.date = NULL,
 #' data(Canada, package = 'vars')
 #' d.vselect <- vars::VARselect(Canada, lag.max = 5, type = 'const')$selection[1]
 #' d.var <- vars::VAR(Canada, p = d.vselect, type = 'const')
-#' ggplot2::autoplot(stats::predict(d.var, n.ahead = 50), is.date = TRUE)
-#' ggplot2::autoplot(stats::predict(d.var, n.ahead = 50), conf.int = FALSE)
+#' autoplot(stats::predict(d.var, n.ahead = 50), is.date = TRUE)
+#' autoplot(stats::predict(d.var, n.ahead = 50), conf.int = FALSE)
 #' @export
 autoplot.varprd <- function(object, is.date = NULL, ts.connect = TRUE,
                             scales = 'free_y',

--- a/R/plotlib.R
+++ b/R/plotlib.R
@@ -11,8 +11,8 @@
 #' @param conf.int.alpha Alpha for confidence intervals
 #' @return ggplot
 #' @examples
-#' d <- ggplot2::fortify(stats::acf(AirPassengers, plot = FALSE))
-#' p <- ggplot2::ggplot(data = d, mapping = ggplot2::aes(x = Lag))
+#' d <- fortify(stats::acf(AirPassengers, plot = FALSE))
+#' p <- ggplot(data = d, mapping = aes(x = Lag))
 #' ggfortify:::plot.conf.int(p)
 plot.conf.int <- function (p, data = NULL, lower = 'lower', upper = 'upper',
                            conf.int = TRUE,

--- a/R/tslib.R
+++ b/R/tslib.R
@@ -1,9 +1,9 @@
 #' Convert \code{ts} index to \code{Date} \code{vector}.
-#' 
+#'
 #' @param data \code{ts} instance
 #' @param is.tsp Logical frag whether data is \code{tsp} itself or not
 #' @param is.date Logical frag indicates whether the \code{stats::ts} is date or not.
-#' If not provided, regard the input as date when the frequency is 4 or 12. 
+#' If not provided, regard the input as date when the frequency is 4 or 12.
 #' @return vector
 #' @examples
 #' ggfortify:::get.dtindex(AirPassengers)
@@ -28,12 +28,12 @@ get.dtindex <- function(data, is.tsp = FALSE, is.date = NULL) {
 }
 
 #' Get \code{Date} \code{vector} continue to \code{ts} index.
-#' 
+#'
 #' @param data \code{ts} instance
 #' @param length A number to continue
 #' @param is.tsp Logical frag whether data is \code{tsp} itself or not
 #' @param is.date Logical frag indicates whether the \code{stats::ts} is date or not.
-#' If not provided, regard the input as date when the frequency is 4 or 12.  
+#' If not provided, regard the input as date when the frequency is 4 or 12.
 #' @return vector
 #' @examples
 #' ggfortify:::get.dtindex.continuous(AirPassengers, length = 10)
@@ -57,9 +57,9 @@ get.dtindex.continuous <- function(data, length, is.tsp = FALSE, is.date = NULL)
 }
 
 #' Check if Validates number of \code{ts} variates
-#' 
+#'
 #' @param data \code{ts} instance
-#' @param raise Logical flag whether raise an error 
+#' @param raise Logical flag whether raise an error
 #' @return logical
 #' @examples
 #' ggfortify:::is.univariate(AirPassengers)
@@ -75,12 +75,12 @@ is.univariate <- function(data, raise = TRUE) {
 }
 
 #' Rbind original and predicted time-series-like instances as fortified \code{data.frame}
-#' 
+#'
 #' @param data Predicted/forecasted \code{ts} instance
 #' @param original Original \code{ts} instance
 #' @param ts.connect Logical frag indicates whether connects original time-series and predicted values
 #' @param index.name Specify column name for time series index
-#' @param data.name Specify column name for univariate time series data. Ignored in multivariate time series. 
+#' @param data.name Specify column name for univariate time series data. Ignored in multivariate time series.
 #' @return data.frame
 #' @examples
 #' predicted <- predict(stats::HoltWinters(UKgas), n.ahead = 5, prediction.interval = TRUE)
@@ -95,7 +95,7 @@ rbind_ts <- function(data, original, ts.connect = TRUE,
 
   dnames <- names(data)
   dnames <- dnames[dnames != index.name]
-  
+
   if (!is.data.frame(original)) {
     original <- ggplot2::fortify(original, index.name = index.name,
                                  data.name = data.name)
@@ -103,18 +103,18 @@ rbind_ts <- function(data, original, ts.connect = TRUE,
   n <- nrow(original)
   rownames(data) <- NULL
   rownames(original) <- NULL
-  
+
   d <- dplyr::rbind_list(original, data)
   if (ts.connect) {
     # Use fnames not to overwrite Index
     d[n, dnames] <- d[n, data.name]
   }
-  dplyr::tbl_df(d)
+  post.fortify(d)
 }
 
 
 #' Calcurate confidence interval for \code{stats::acf}
-#' 
+#'
 #' @param x \code{stats::acf} instance
 #' @param ci Float value for confidence interval
 #' @param ci.type "white" or "ma"
@@ -124,7 +124,7 @@ rbind_ts <- function(data, original, ts.connect = TRUE,
 #' ggfortify:::confint.acf(air.acf)
 #' ggfortify:::confint.acf(air.acf, ci.type = 'ma')
 confint.acf <- function (x, ci = 0.95, ci.type = "white") {
-  if ((nser <- ncol(x$lag)) < 1L) 
+  if ((nser <- ncol(x$lag)) < 1L)
     stop("x$lag must have at least 1 column")
   with.ci <- ci > 0 && x$type != "covariance"
   with.ci.ma <- with.ci && ci.type == "ma" && x$type == "correlation"
@@ -133,13 +133,13 @@ confint.acf <- function (x, ci = 0.95, ci.type = "white") {
     warning("can use ci.type=\"ma\" only if first lag is 0")
     with.ci.ma <- FALSE
   }
-  clim0 <- if (with.ci) 
+  clim0 <- if (with.ci)
     qnorm((1 + ci)/2)/sqrt(x$n.used)
   else c(0, 0)
-  
+
   Npgs <- 1L
   nr <- nser
-  
+
   if (nser > 1L) {
     Npgs <- nser
     nr <- ceiling(nser / Npgs)
@@ -152,7 +152,7 @@ confint.acf <- function (x, ci = 0.95, ci.type = "white") {
     for (i in iind) {
       for (j in jind) {
         if (!(max(i, j) > nser)) {
-          clim <- if (with.ci.ma && i == j) 
+          clim <- if (with.ci.ma && i == j)
             clim0 * sqrt(cumsum(c(1, 2 * x$acf[-1, i, j]^2)))
           else clim0
 
@@ -172,7 +172,7 @@ confint.acf <- function (x, ci = 0.95, ci.type = "white") {
 }
 
 #' Calcurate fitted values for \code{stats::ar}
-#' 
+#'
 #' @param object \code{stats::ar} instance
 #' @param ... other keywords
 #' @return ts An time series of the one-step forecasts
@@ -186,7 +186,7 @@ fitted.ar <- function(object, ...) {
 }
 
 #' Calcurate residuals for \code{stats::ar}
-#' 
+#'
 #' @param object \code{stats::ar} instance
 #' @param ... other keywords
 #' @return ts Residuals extracted from the object object.
@@ -198,7 +198,7 @@ residuals.ar <- function(object, ...) {
 }
 
 #' Plots a cumulative periodogram.
-#' 
+#'
 #' @param ts \code{stats::ts} instance
 #' @param taper Proportion tapered in forming the periodogram
 #' @param colour Line colour
@@ -212,7 +212,7 @@ residuals.ar <- function(object, ...) {
 #' @examples
 #' ggcpgram(AirPassengers)
 #' @export
-ggcpgram <- function (ts, taper = 0.1, 
+ggcpgram <- function (ts, taper = 0.1,
                       colour = '#000000', linetype = 'solid',
                       conf.int = TRUE,
                       conf.int.colour = '#0000FF', conf.int.linetype = 'dashed',
@@ -244,7 +244,7 @@ ggcpgram <- function (ts, taper = 0.1,
     geom_line(colour = colour, linetype = linetype) +
     ggplot2::scale_x_continuous(name = '', limits = c(0, xm)) +
     ggplot2::scale_y_continuous(name = '', limits = c(0, 1))
-  
+
   p <- plot.conf.int(p, conf.int = conf.int,
                      conf.int.colour = conf.int.colour,
                      conf.int.linetype = conf.int.linetype,
@@ -254,7 +254,7 @@ ggcpgram <- function (ts, taper = 0.1,
 }
 
 #' Plots time-series diagnostics.
-#' 
+#'
 #' @param object A fitted time-series model
 #' @param gof.lag The maximum number of lags for a Portmanteau goodness-of-fit test
 #' @param conf.int Logical flag indicating whether to plot confidence intervals
@@ -272,11 +272,11 @@ ggcpgram <- function (ts, taper = 0.1,
 #' @examples
 #' ggtsdiag(arima(AirPassengers))
 #' @export
-ggtsdiag <- function(object, gof.lag = 10, 
+ggtsdiag <- function(object, gof.lag = 10,
                      conf.int = TRUE,
                      conf.int.colour = '#0000FF', conf.int.linetype = 'dashed',
                      conf.int.fill = NULL, conf.int.alpha = 0.3,
-                     ad.colour = '#888888', ad.linetype = 'dashed', ad.size = .2, 
+                     ad.colour = '#888888', ad.linetype = 'dashed', ad.size = .2,
                      nrow = NULL, ncol = 1, ...) {
   rs <- residuals(object)
   if (is.null(rs)) {
@@ -285,12 +285,12 @@ ggtsdiag <- function(object, gof.lag = 10,
   if (is.null(rs)) {
     rs <- object$resid
   }
-  
+
   stdres <- rs / sqrt(object$sigma2)
   p.std <- ggplot2::autoplot(stdres) +
     ggplot2::geom_hline(yintercept = 0,
                         linetype = ad.linetype, size = ad.size,
-                        colour = ad.colour) + 
+                        colour = ad.colour) +
     ggplot2::ggtitle('Standardized Residuals')
 
   acfobj <- stats::acf(rs, plot = FALSE, na.action = na.pass)
@@ -300,7 +300,7 @@ ggtsdiag <- function(object, gof.lag = 10,
                         conf.int.fill = conf.int.fill,
                         conf.int.alpha = conf.int.alpha)
   p.acf <- p.acf + ggplot2::ggtitle('ACF of Residuals')
-  
+
   nlag <- gof.lag
   pval <- numeric(nlag)
   for (i in 1L:nlag) pval[i] <- Box.test(rs, i, type = "Ljung-Box")$p.value
@@ -324,7 +324,7 @@ ggtsdiag <- function(object, gof.lag = 10,
 }
 
 #' Plot time series against lagged versions of themselves.
-#' 
+#'
 #' @param ts \code{stats::ts} instance
 #' @param lags Number of lag plots desired
 #' @param nrow Number of plot rows
@@ -340,11 +340,11 @@ gglagplot <- function(ts, lags = 1, nrow = NULL, ncol = NULL) {
   n <- nrow(ts)
   nser <- 1
   tot.lags <- nser * lags
-  
+
   if (is.null(nrow) && is.null(ncol)) {
     nrow <- ceiling(sqrt(tot.lags))
   }
-  
+
   .lag <- function(k) {
     result <- as.vector(lag(ts, k))
     result <- data.frame(Data = as.vector(ts),
@@ -355,7 +355,7 @@ gglagplot <- function(ts, lags = 1, nrow = NULL, ncol = NULL) {
   lag.df <- dplyr::rbind_all(lapply(seq(1:lags), .lag))
   lag.df <- dplyr::filter(lag.df, !is.na(Lag))
   lag.df$Lag_dist <- as.factor(lag.df$Lag_dist)
-  
+
   mapping = ggplot2::aes_string(x = 'Lag', y = 'Data')
   p <- ggplot2::ggplot(data = lag.df, mapping = mapping) +
     ggplot2::geom_point() +
@@ -364,7 +364,7 @@ gglagplot <- function(ts, lags = 1, nrow = NULL, ncol = NULL) {
 }
 
 #' Plot seasonal subseries of time series, generalization of \code{stats::monthplot}
-#' 
+#'
 #' @param data \code{stats::ts} instance
 #' @param freq Length of frequency. If not provided, use time-series frequency
 #' @param nrow Number of plot rows
@@ -389,30 +389,30 @@ ggfreqplot <- function(data, freq = NULL,
                        conf.int.value = 0.95,
                        ...) {
   is.univariate(data)
-  
+
   if (is.null(freq)) {
     freq <- frequency(data)
   }
-  
+
   if (is.null(nrow) && is.null(ncol)) {
     nrow <- ceiling(sqrt(freq))
   }
-  
+
   d <- ggplot2::fortify(data)
   freqd <- data.frame(Frequency = rep(1:freq, length.out = length(data)))
   d <- cbind(d, freqd)
 
   summarised <- dplyr::group_by_(d, 'Frequency') %>%
     dplyr::summarise_(m = 'mean(Data)', s = 'sd(Data)')
-  
+
   p <- (1 - conf.int.value) / 2
   summarised <- dplyr::mutate(summarised,
                               lower = qnorm(p, mean = m, sd = s),
                               upper = qnorm(1 - p, mean = m, sd = s))
   d <- dplyr::left_join(d, summarised, by = 'Frequency')
-  
+
   p <- autoplot.ts(d, columns = 'Data', ...)
-  p <- p + ggplot2::geom_line(mapping = ggplot2::aes_string(y = 'm'), 
+  p <- p + ggplot2::geom_line(mapping = ggplot2::aes_string(y = 'm'),
                        colour = conf.int.colour) +
     ggplot2::facet_wrap(~Frequency)
   p <- plot.conf.int(p, conf.int = conf.int,

--- a/R/util.R
+++ b/R/util.R
@@ -92,3 +92,14 @@ stop.unsupported.type <- function() {
   stop(paste0('Unsupported class for autoplot: ', class(data)), call. = FALSE)
 }
 
+
+#' Post process for fortify.
+#'
+#' @param data data.frame
+#' @return data.frame
+post.fortify <- function(data) {
+  # does nothing in current version
+  # dplyr::tbl_df(data)
+  data
+}
+

--- a/ggfortify.Rproj
+++ b/ggfortify.Rproj
@@ -18,5 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
-PackageCheckArgs: --no-manual
 PackageRoxygenize: rd,namespace

--- a/man/autoplot.MSM.lm.Rd
+++ b/man/autoplot.MSM.lm.Rd
@@ -28,6 +28,6 @@ d <- data.frame(Data = c(rnorm(50, mean = -10), rnorm(50, mean = 10)),
                 exog = cos(seq(-pi/2, pi/2, length.out = 100)))
 d.mswm <- MSwM::msmFit(lm(Data ~.-1, data = d), k=2, sw=rep(TRUE, 2),
                        control = list(parallelization = FALSE))
-ggplot2::autoplot(d.mswm)
+autoplot(d.mswm)
 }
 

--- a/man/autoplot.acf.Rd
+++ b/man/autoplot.acf.Rd
@@ -40,8 +40,8 @@ ggplot
 Autoplot \code{stats::acf}.
 }
 \examples{
-ggplot2::autoplot(stats::acf(AirPassengers))
-ggplot2::autoplot(stats::pacf(AirPassengers))
-ggplot2::autoplot(stats::ccf(AirPassengers, AirPassengers))
+autoplot(stats::acf(AirPassengers))
+autoplot(stats::pacf(AirPassengers))
+autoplot(stats::ccf(AirPassengers, AirPassengers))
 }
 

--- a/man/autoplot.breakpoints.Rd
+++ b/man/autoplot.breakpoints.Rd
@@ -30,8 +30,8 @@ Autoplot \code{strucchange::breakpoints}.
 \examples{
 library(strucchange)
 bp.nile <- breakpoints(Nile ~ 1)
-ggplot2::autoplot(bp.nile)
-ggplot2::autoplot(bp.nile, is.date = TRUE)
-ggplot2::autoplot(breakpoints(bp.nile, breaks = 2), data = Nile)
+autoplot(bp.nile)
+autoplot(bp.nile, is.date = TRUE)
+autoplot(breakpoints(bp.nile, breaks = 2), data = Nile)
 }
 

--- a/man/autoplot.cpt.Rd
+++ b/man/autoplot.cpt.Rd
@@ -27,7 +27,7 @@ Autoplot \code{changepoint::cpt}.
 }
 \examples{
 library(changepoint)
-ggplot2::autoplot(cpt.mean(AirPassengers))
-ggplot2::autoplot(cpt.meanvar(AirPassengers))
+autoplot(cpt.mean(AirPassengers))
+autoplot(cpt.meanvar(AirPassengers))
 }
 

--- a/man/autoplot.density.Rd
+++ b/man/autoplot.density.Rd
@@ -29,6 +29,6 @@ ggplot
 Autoplot \code{stats::density}
 }
 \examples{
-ggplot2::autoplot(stats::density(stats::rnorm(1:50)))
+autoplot(stats::density(stats::rnorm(1:50)))
 }
 

--- a/man/autoplot.ets.Rd
+++ b/man/autoplot.ets.Rd
@@ -22,8 +22,8 @@ Autoplot \code{forecast::bats} and \code{forecast::ets}
 }
 \examples{
 d.bats <- forecast::bats(UKgas)
-ggplot2::autoplot(d.bats)
-ggplot2::autoplot(d.bats, columns = 'Residuals')
-ggplot2::autoplot(forecast::ets(UKgas))
+autoplot(d.bats)
+autoplot(d.bats, columns = 'Residuals')
+autoplot(forecast::ets(UKgas))
 }
 

--- a/man/autoplot.forecast.Rd
+++ b/man/autoplot.forecast.Rd
@@ -41,11 +41,11 @@ Autoplot \code{forecast::forecast}.
 }
 \examples{
 d.arima <- forecast::auto.arima(AirPassengers)
-ggplot2::autoplot(forecast::forecast(d.arima, h = 10))
-ggplot2::autoplot(forecast::forecast(d.arima, level = c(85), h = 10))
-ggplot2::autoplot(forecast::forecast(d.arima, h = 5), conf.int = FALSE)
-ggplot2::autoplot(forecast::forecast(d.arima, h = 10), is.date = FALSE)
-ggplot2::autoplot(forecast::forecast(forecast::ets(UKgas), h = 5))
-ggplot2::autoplot(forecast::forecast(stats::HoltWinters(UKgas), h = 10))
+autoplot(forecast::forecast(d.arima, h = 10))
+autoplot(forecast::forecast(d.arima, level = c(85), h = 10))
+autoplot(forecast::forecast(d.arima, h = 5), conf.int = FALSE)
+autoplot(forecast::forecast(d.arima, h = 10), is.date = FALSE)
+autoplot(forecast::forecast(forecast::ets(UKgas), h = 5))
+autoplot(forecast::forecast(stats::HoltWinters(UKgas), h = 10))
 }
 

--- a/man/autoplot.kmeans.Rd
+++ b/man/autoplot.kmeans.Rd
@@ -24,12 +24,11 @@ Autoplot \code{stats::kmeans}, \code{cluster::clara}, \code{cluster::fanny} and
 \code{cluster::pam}.
 }
 \examples{
-df <- iris[-5]
-ggplot2::autoplot(stats::kmeans(df, 3), data = iris)
-ggplot2::autoplot(cluster::clara(df, 3), label = TRUE)
-ggplot2::autoplot(cluster::fanny(df, 3))
-ggplot2::autoplot(cluster::fanny(df, 3), frame = TRUE)
-ggplot2::autoplot(cluster::pam(df, 3), data = iris)
-ggplot2::autoplot(cluster::pam(df, 3), data = iris, frame = TRUE, frame.type = 't')
+autoplot(stats::kmeans(iris[-5], 3), data = iris)
+autoplot(cluster::clara(iris[-5], 3), label = TRUE)
+autoplot(cluster::fanny(iris[-5], 3))
+autoplot(cluster::fanny(iris[-5], 3), frame = TRUE)
+autoplot(cluster::pam(iris[-5], 3), data = iris)
+autoplot(cluster::pam(iris[-5], 3), data = iris, frame = TRUE, frame.type = 't')
 }
 

--- a/man/autoplot.lm.Rd
+++ b/man/autoplot.lm.Rd
@@ -48,10 +48,10 @@ ggplot
 Autoplot \code{stats::lm}.
 }
 \examples{
-ggplot2::autoplot(lm(Petal.Width ~ Petal.Length, data= iris))
-ggplot2::autoplot(glm(Petal.Width ~ Petal.Length, data= iris), which = 1:6)
+autoplot(lm(Petal.Width ~ Petal.Length, data= iris))
+autoplot(glm(Petal.Width ~ Petal.Length, data= iris), which = 1:6)
 
-ggplot2::autoplot(lm(Petal.Width~Petal.Length, data = iris)) + ggplot2::theme_bw()
-ggplot2::autoplot(lm(Petal.Width~Petal.Length, data = iris)) + ggplot2::scale_colour_brewer()
+autoplot(lm(Petal.Width~Petal.Length, data = iris)) + theme_bw()
+autoplot(lm(Petal.Width~Petal.Length, data = iris)) + scale_colour_brewer()
 }
 

--- a/man/autoplot.matrix.Rd
+++ b/man/autoplot.matrix.Rd
@@ -37,10 +37,10 @@ ggplot
 Plot \code{base::matrix}
 }
 \examples{
-ggplot2::autoplot(matrix(rnorm(20), nc = 5))
-ggplot2::autoplot(matrix(rnorm(20), nc = 5), fill = 'red')
-ggplot2::autoplot(matrix(rnorm(20), nc = 5),
-                  scale = ggplot2::scale_fill_gradient(low = 'red', high = 'blue'))
-ggplot2::autoplot(matrix(rnorm(20), nc = 2), geom = 'point')
+autoplot(matrix(rnorm(20), nc = 5))
+autoplot(matrix(rnorm(20), nc = 5), fill = 'red')
+autoplot(matrix(rnorm(20), nc = 5),
+         scale = scale_fill_gradient(low = 'red', high = 'blue'))
+autoplot(matrix(rnorm(20), nc = 2), geom = 'point')
 }
 

--- a/man/autoplot.pca_common.Rd
+++ b/man/autoplot.pca_common.Rd
@@ -59,25 +59,24 @@ ggplot
 Autoplot PCA-likes.
 }
 \examples{
-df <- iris[-5]
-ggplot2::autoplot(stats::prcomp(df))
-ggplot2::autoplot(stats::prcomp(df), data = iris)
-ggplot2::autoplot(stats::prcomp(df), data = iris, colour = 'Species')
-ggplot2::autoplot(stats::prcomp(df), label = TRUE, loadings = TRUE, loadings.label = TRUE)
-ggplot2::autoplot(stats::prcomp(df), frame = TRUE)
-ggplot2::autoplot(stats::prcomp(df), data = iris, frame = TRUE,
-                  frame.colour = 'Species')
-ggplot2::autoplot(stats::prcomp(df), data = iris, frame = TRUE,
-                  frame.type = 't', frame.colour = 'Species')
+autoplot(stats::prcomp(iris[-5]))
+autoplot(stats::prcomp(iris[-5]), data = iris)
+autoplot(stats::prcomp(iris[-5]), data = iris, colour = 'Species')
+autoplot(stats::prcomp(iris[-5]), label = TRUE, loadings = TRUE, loadings.label = TRUE)
+autoplot(stats::prcomp(iris[-5]), frame = TRUE)
+autoplot(stats::prcomp(iris[-5]), data = iris, frame = TRUE,
+         frame.colour = 'Species')
+autoplot(stats::prcomp(iris[-5]), data = iris, frame = TRUE,
+         frame.type = 't', frame.colour = 'Species')
 
-ggplot2::autoplot(stats::princomp(df))
-ggplot2::autoplot(stats::princomp(df), data = iris)
-ggplot2::autoplot(stats::princomp(df), data = iris, colour = 'Species')
-ggplot2::autoplot(stats::princomp(df), label = TRUE, loadings = TRUE, loadings.label = TRUE)
+autoplot(stats::princomp(iris[-5]))
+autoplot(stats::princomp(iris[-5]), data = iris)
+autoplot(stats::princomp(iris[-5]), data = iris, colour = 'Species')
+autoplot(stats::princomp(iris[-5]), label = TRUE, loadings = TRUE, loadings.label = TRUE)
 
 d.factanal <- stats::factanal(state.x77, factors = 3, scores = 'regression')
-ggplot2::autoplot(d.factanal)
-ggplot2::autoplot(d.factanal, data = state.x77, colour = 'Income')
-ggplot2::autoplot(d.factanal, label = TRUE, loadings = TRUE, loadings.label = TRUE)
+autoplot(d.factanal)
+autoplot(d.factanal, data = state.x77, colour = 'Income')
+autoplot(d.factanal, label = TRUE, loadings = TRUE, loadings.label = TRUE)
 }
 

--- a/man/autoplot.spec.Rd
+++ b/man/autoplot.spec.Rd
@@ -18,7 +18,7 @@ ggplot
 Autoplot \code{stats::spec}.
 }
 \examples{
-ggplot2::autoplot(stats::spec.ar(AirPassengers))
-ggplot2::autoplot(stats::spec.pgram(AirPassengers))
+autoplot(stats::spec.ar(AirPassengers))
+autoplot(stats::spec.pgram(AirPassengers))
 }
 

--- a/man/autoplot.survfit.Rd
+++ b/man/autoplot.survfit.Rd
@@ -44,10 +44,10 @@ Autoplot \code{survival::survfit}.
 }
 \examples{
 d.survfit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
-ggplot2::autoplot(d.survfit)
-ggplot2::autoplot(d.survfit, conf.int = FALSE, censor = FALSE)
+autoplot(d.survfit)
+autoplot(d.survfit, conf.int = FALSE, censor = FALSE)
 
 d.coxph <- survival::coxph(survival::Surv(time, status) ~ sex, data = survival::lung)
-ggplot2::autoplot(survival::survfit(d.coxph))
+autoplot(survival::survfit(d.coxph))
 }
 

--- a/man/autoplot.ts.Rd
+++ b/man/autoplot.ts.Rd
@@ -61,24 +61,24 @@ Autoplot time-series-like.
 }
 \examples{
 data(Canada, package = 'vars')
-ggplot2::autoplot(AirPassengers)
-ggplot2::autoplot(UKgas, ts.geom = 'bar')
-ggplot2::autoplot(Canada)
-ggplot2::autoplot(Canada, columns = 'e', is.date = TRUE)
-ggplot2::autoplot(Canada, facets = FALSE)
+autoplot(AirPassengers)
+autoplot(UKgas, ts.geom = 'bar')
+autoplot(Canada)
+autoplot(Canada, columns = 'e', is.date = TRUE)
+autoplot(Canada, facets = FALSE)
 
 library(zoo)
-ggplot2::autoplot(xts::as.xts(AirPassengers))
-ggplot2::autoplot(xts::as.xts(UKgas))
-ggplot2::autoplot(xts::as.xts(Canada))
+autoplot(xts::as.xts(AirPassengers))
+autoplot(xts::as.xts(UKgas))
+autoplot(xts::as.xts(Canada))
 
-ggplot2::autoplot(timeSeries::as.timeSeries(AirPassengers))
-ggplot2::autoplot(timeSeries::as.timeSeries(Canada))
+autoplot(timeSeries::as.timeSeries(AirPassengers))
+autoplot(timeSeries::as.timeSeries(Canada))
 
 its <- tseries::irts(cumsum(rexp(10, rate = 0.1)), matrix(rnorm(20), ncol=2))
-ggplot2::autoplot(its)
+autoplot(its)
 
-ggplot2::autoplot(stats::stl(UKgas, s.window = 'periodic'))
-ggplot2::autoplot(stats::decompose(UKgas))
+autoplot(stats::stl(UKgas, s.window = 'periodic'))
+autoplot(stats::decompose(UKgas))
 }
 

--- a/man/autoplot.tsmodel.Rd
+++ b/man/autoplot.tsmodel.Rd
@@ -59,23 +59,23 @@ Autoplot time series models (like AR, ARIMA).
 }
 \examples{
 d.ar <- stats::ar(AirPassengers)
-ggplot2::autoplot(d.ar)
-ggplot2::autoplot(d.ar, predict = predict(d.ar, n.ahead = 5))
-ggplot2::autoplot(stats::arima(UKgas), data = UKgas)
-ggplot2::autoplot(forecast::arfima(AirPassengers))
-ggplot2::autoplot(forecast::nnetar(UKgas), is.date = FALSE)
+autoplot(d.ar)
+autoplot(d.ar, predict = predict(d.ar, n.ahead = 5))
+autoplot(stats::arima(UKgas), data = UKgas)
+autoplot(forecast::arfima(AirPassengers))
+autoplot(forecast::nnetar(UKgas), is.date = FALSE)
 
 d.holt <- stats::HoltWinters(USAccDeaths)
-ggplot2::autoplot(d.holt)
-ggplot2::autoplot(d.holt, predict = predict(d.holt, n.ahead = 5))
-ggplot2::autoplot(d.holt, predict = predict(d.holt, n.ahead = 5, prediction.interval = TRUE))
+autoplot(d.holt)
+autoplot(d.holt, predict = predict(d.holt, n.ahead = 5))
+autoplot(d.holt, predict = predict(d.holt, n.ahead = 5, prediction.interval = TRUE))
 
 form <- function(theta){
   dlm::dlmModPoly(order=1, dV=exp(theta[1]), dW=exp(theta[2]))
 }
 model <- form(dlm::dlmMLE(Nile, parm=c(1, 1), form)$par)
 filtered <- dlm::dlmFilter(Nile, model)
-ggplot2::autoplot(filtered)
-ggplot2::autoplot(dlm::dlmSmooth(filtered))
+autoplot(filtered)
+autoplot(dlm::dlmSmooth(filtered))
 }
 

--- a/man/autoplot.varprd.Rd
+++ b/man/autoplot.varprd.Rd
@@ -46,7 +46,7 @@ Autoplot \code{vars::varprd}.
 data(Canada, package = 'vars')
 d.vselect <- vars::VARselect(Canada, lag.max = 5, type = 'const')$selection[1]
 d.var <- vars::VAR(Canada, p = d.vselect, type = 'const')
-ggplot2::autoplot(stats::predict(d.var, n.ahead = 50), is.date = TRUE)
-ggplot2::autoplot(stats::predict(d.var, n.ahead = 50), conf.int = FALSE)
+autoplot(stats::predict(d.var, n.ahead = 50), is.date = TRUE)
+autoplot(stats::predict(d.var, n.ahead = 50), conf.int = FALSE)
 }
 

--- a/man/fortify.MSM.lm.Rd
+++ b/man/fortify.MSM.lm.Rd
@@ -27,6 +27,6 @@ d <- data.frame(Data = c(rnorm(50, mean = -10), rnorm(50, mean = 10)),
                 exog = cos(seq(-pi/2, pi/2, length.out = 100)))
 d.mswm <- MSwM::msmFit(lm(Data ~.-1, data = d), k=2, sw=rep(TRUE, 2),
                        control = list(parallelization = FALSE))
-ggplot2::fortify(d.mswm)
+fortify(d.mswm)
 }
 

--- a/man/fortify.acf.Rd
+++ b/man/fortify.acf.Rd
@@ -27,10 +27,10 @@ data.frame
 Convert \code{stats::acf} to \code{data.frame}.
 }
 \examples{
-ggplot2::fortify(stats::acf(AirPassengers))
-ggplot2::fortify(stats::pacf(AirPassengers))
-ggplot2::fortify(stats::ccf(AirPassengers, AirPassengers))
+fortify(stats::acf(AirPassengers))
+fortify(stats::pacf(AirPassengers))
+fortify(stats::ccf(AirPassengers, AirPassengers))
 
-ggplot2::fortify(stats::acf(AirPassengers), conf.int = TRUE)
+fortify(stats::acf(AirPassengers), conf.int = TRUE)
 }
 

--- a/man/fortify.cpt.Rd
+++ b/man/fortify.cpt.Rd
@@ -29,14 +29,14 @@ Convert \code{changepoint::cpt} and \code{strucchange::breakpoints} to data.fram
 }
 \examples{
 library(changepoint)
-ggplot2::fortify(cpt.mean(AirPassengers))
-ggplot2::fortify(cpt.var(AirPassengers))
-ggplot2::fortify(cpt.meanvar(AirPassengers))
+fortify(cpt.mean(AirPassengers))
+fortify(cpt.var(AirPassengers))
+fortify(cpt.meanvar(AirPassengers))
 
 library(strucchange)
 bp.nile <- breakpoints(Nile ~ 1)
-ggplot2::fortify(bp.nile)
-ggplot2::fortify(breakpoints(bp.nile, breaks = 2))
-ggplot2::fortify(breakpoints(bp.nile, breaks = 2), data = Nile)
+fortify(bp.nile)
+fortify(breakpoints(bp.nile, breaks = 2))
+fortify(breakpoints(bp.nile, breaks = 2), data = Nile)
 }
 

--- a/man/fortify.density.Rd
+++ b/man/fortify.density.Rd
@@ -20,6 +20,6 @@ data.frame
 Convert \code{stats::density} to \code{data.frame}.
 }
 \examples{
-ggplot2::fortify(stats::density(stats::rnorm(1:50)))
+fortify(stats::density(stats::rnorm(1:50)))
 }
 

--- a/man/fortify.dist.Rd
+++ b/man/fortify.dist.Rd
@@ -20,6 +20,6 @@ data.frame
 Convert \code{stats::dist} to data.frame.
 }
 \examples{
-ggplot2::fortify(eurodist)
+fortify(eurodist)
 }
 

--- a/man/fortify.ets.Rd
+++ b/man/fortify.ets.Rd
@@ -20,7 +20,7 @@ data.frame
 Convert \code{forecast::bats} and \code{forecast::ets} to data.frame.
 }
 \examples{
-ggplot2::fortify(forecast::bats(UKgas))
-ggplot2::fortify(forecast::ets(UKgas))
+fortify(forecast::bats(UKgas))
+fortify(forecast::ets(UKgas))
 }
 

--- a/man/fortify.factanal.Rd
+++ b/man/fortify.factanal.Rd
@@ -23,7 +23,7 @@ Convert \code{stats::factanal} to data.frame.
 }
 \examples{
 d.factanal <- stats::factanal(state.x77, factors = 3, scores = 'regression')
-ggplot2::fortify(d.factanal)
-ggplot2::fortify(d.factanal, data = state.x77)
+fortify(d.factanal)
+fortify(d.factanal, data = state.x77)
 }
 

--- a/man/fortify.forecast.Rd
+++ b/man/fortify.forecast.Rd
@@ -28,7 +28,7 @@ Convert \code{forecast::forecast} to data.frame.
 \examples{
 d.arima <- forecast::auto.arima(AirPassengers)
 d.forecast <- forecast::forecast(d.arima, level = c(95), h = 50)
-ggplot2::fortify(d.forecast)
-ggplot2::fortify(d.forecast, ts.connect = TRUE)
+fortify(d.forecast)
+fortify(d.forecast, ts.connect = TRUE)
 }
 

--- a/man/fortify.kmeans.Rd
+++ b/man/fortify.kmeans.Rd
@@ -24,11 +24,10 @@ Convert \code{stats::kmeans}, \code{cluster::clara}, \code{cluster::fanny} and
 \code{cluster::pam} to data.frame.
 }
 \examples{
-df <- iris[-5]
-ggplot2::fortify(stats::kmeans(df, 3))
-ggplot2::fortify(stats::kmeans(df, 3), data = iris)
-ggplot2::fortify(cluster::clara(df, 3))
-ggplot2::fortify(cluster::fanny(df, 3))
-ggplot2::fortify(cluster::pam(df, 3), data = iris)
+fortify(stats::kmeans(iris[-5], 3))
+fortify(stats::kmeans(iris[-5], 3), data = iris)
+fortify(cluster::clara(iris[-5], 3))
+fortify(cluster::fanny(iris[-5], 3))
+fortify(cluster::pam(iris[-5], 3), data = iris)
 }
 

--- a/man/fortify.matrix.Rd
+++ b/man/fortify.matrix.Rd
@@ -24,6 +24,6 @@ data.frame
 Different from \code{as.data.frame},
 }
 \examples{
-ggplot2::fortify(matrix(1:6, nrow=2, ncol=3))
+fortify(matrix(1:6, nrow=2, ncol=3))
 }
 

--- a/man/fortify.prcomp.Rd
+++ b/man/fortify.prcomp.Rd
@@ -23,11 +23,10 @@ data.frame
 Convert \code{stats::prcomp}, \code{stats::princomp} to data.frame.
 }
 \examples{
-df <- iris[-5]
-ggplot2::fortify(stats::prcomp(df))
-ggplot2::fortify(stats::prcomp(df), data = iris)
+fortify(stats::prcomp(iris[-5]))
+fortify(stats::prcomp(iris[-5]), data = iris)
 
-ggplot2::fortify(stats::princomp(df))
-ggplot2::fortify(stats::princomp(df), data = iris)
+fortify(stats::princomp(iris[-5]))
+fortify(stats::princomp(iris[-5]), data = iris)
 }
 

--- a/man/fortify.spec.Rd
+++ b/man/fortify.spec.Rd
@@ -20,8 +20,8 @@ data.frame
 Convert \code{stats::spec} to data.frame.
 }
 \examples{
-ggplot2::fortify(spectrum(AirPassengers))
-ggplot2::fortify(stats::spec.ar(AirPassengers))
-ggplot2::fortify(stats::spec.pgram(AirPassengers))
+fortify(spectrum(AirPassengers))
+fortify(stats::spec.ar(AirPassengers))
+fortify(stats::spec.pgram(AirPassengers))
 }
 

--- a/man/fortify.survfit.Rd
+++ b/man/fortify.survfit.Rd
@@ -22,9 +22,9 @@ Convert \code{survival::survfit} to data.frame.
 }
 \examples{
 d.survfit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
-ggplot2::fortify(d.survfit)
+fortify(d.survfit)
 
 d.coxph <- survival::coxph(survival::Surv(time, status) ~ sex, data = survival::lung)
-ggplot2::fortify(survival::survfit(d.coxph))
+fortify(survival::survfit(d.coxph))
 }
 

--- a/man/fortify.table.Rd
+++ b/man/fortify.table.Rd
@@ -20,6 +20,6 @@ data.frame
 Convert \code{base::table} to data.frame.
 }
 \examples{
-ggplot2::fortify(Titanic)
+fortify(Titanic)
 }
 

--- a/man/fortify.ts.Rd
+++ b/man/fortify.ts.Rd
@@ -35,13 +35,13 @@ data.frame
 Convert time-series-like to data.frame.
 }
 \examples{
-ggplot2::fortify(AirPassengers)
-ggplot2::fortify(timeSeries::as.timeSeries(AirPassengers))
+fortify(AirPassengers)
+fortify(timeSeries::as.timeSeries(AirPassengers))
 
 its <- tseries::irts(cumsum(rexp(10, rate = 0.1)), matrix(rnorm(20), ncol=2))
-ggplot2::fortify(its)
+fortify(its)
 
-ggplot2::fortify(stats::stl(UKgas, s.window = 'periodic'))
-ggplot2::fortify(stats::decompose(UKgas))
+fortify(stats::stl(UKgas, s.window = 'periodic'))
+fortify(stats::decompose(UKgas))
 }
 

--- a/man/fortify.tsmodel.Rd
+++ b/man/fortify.tsmodel.Rd
@@ -37,17 +37,17 @@ data.frame
 Convert time series models (like AR, ARIMA) to data.frame.
 }
 \examples{
-ggplot2::fortify(stats::ar(AirPassengers))
-ggplot2::fortify(stats::arima(UKgas))
-ggplot2::fortify(stats::arima(UKgas), data = UKgas, is.date = TRUE)
-ggplot2::fortify(forecast::auto.arima(austres))
-ggplot2::fortify(forecast::arfima(AirPassengers))
-ggplot2::fortify(forecast::nnetar(UKgas))
-ggplot2::fortify(stats::HoltWinters(USAccDeaths))
+fortify(stats::ar(AirPassengers))
+fortify(stats::arima(UKgas))
+fortify(stats::arima(UKgas), data = UKgas, is.date = TRUE)
+fortify(forecast::auto.arima(austres))
+fortify(forecast::arfima(AirPassengers))
+fortify(forecast::nnetar(UKgas))
+fortify(stats::HoltWinters(USAccDeaths))
 
 data(LPP2005REC, package = 'timeSeries')
 x = timeSeries::as.timeSeries(LPP2005REC)
 d.Garch = fGarch::garchFit(LPP40 ~ garch(1, 1), data = 100 * x, trace = FALSE)
-ggplot2::fortify(d.Garch)
+fortify(d.Garch)
 }
 

--- a/man/fortify.varprd.Rd
+++ b/man/fortify.varprd.Rd
@@ -31,6 +31,6 @@ Convert \code{vars::varprd} to data.frame.
 data(Canada, package = 'vars')
 d.vselect <- vars::VARselect(Canada, lag.max = 5, type = 'const')$selection[1]
 d.var <- vars::VAR(Canada, p = d.vselect, type = 'const')
-ggplot2::fortify(stats::predict(d.var, n.ahead = 50))
+fortify(stats::predict(d.var, n.ahead = 50))
 }
 

--- a/man/plot.conf.int.Rd
+++ b/man/plot.conf.int.Rd
@@ -35,8 +35,8 @@ ggplot
 Attach confidence interval to \code{ggplot2::ggplot}
 }
 \examples{
-d <- ggplot2::fortify(stats::acf(AirPassengers, plot = FALSE))
-p <- ggplot2::ggplot(data = d, mapping = ggplot2::aes(x = Lag))
+d <- fortify(stats::acf(AirPassengers, plot = FALSE))
+p <- ggplot(data = d, mapping = aes(x = Lag))
 ggfortify:::plot.conf.int(p)
 }
 

--- a/notes/basics.Rmd
+++ b/notes/basics.Rmd
@@ -70,7 +70,7 @@ p + scale_colour_brewer()
 
 Internally, `autoplot` calls a generic function named `ggplot2::fortify` to convert the input to `data.frame`. As `ggfortify` defines `fortify` function for all the supported classes, you can use `fortify` to convert the instance to plot-friendly `data.frame`.
 
-**NOTE** Precisely, `fortify` functions defined in `ggfortify` return tractable `dplyr::tbl_df` instance.
+**NOTE** In v0.0.1, `fortify` functions returns `dplyr::tbl_df`. As of v0.0.2, `fortify` returns normal `data.frame` because `dplyr` v0.4.0 or later no longer preserves `rownames` which may be required for plotting.
 
 If you want a different type of plot, you can use `fortify` to get `data.frame`, then call `ggplot` in a normal way.
 
@@ -78,7 +78,7 @@ Following example shows a bar plot counting k-means clusters.
 
 ```{r}
 df <- fortify(kmeans(iris[-5], 3), data = iris)
-df
+head(df)
 
 ggplot(df, aes(x= cluster, fill = cluster)) + geom_bar()
 ```

--- a/notes/plot_pca.Rmd
+++ b/notes/plot_pca.Rmd
@@ -77,10 +77,9 @@ autoplot(d.factanal, label = TRUE, loadings = TRUE, loadings.label = TRUE)
 
 ```{r, message = FALSE}
 set.seed(1)
-df <- iris[-5]
-autoplot(kmeans(df, 3), data = iris)
+autoplot(kmeans(USArrests, 3), data = USArrests)
 
-autoplot(kmeans(df, 3), data = iris, label = TRUE)
+autoplot(kmeans(USArrests, 3), data = USArrests, label = TRUE)
 ```
 
 # Plotting cluster package
@@ -89,19 +88,19 @@ autoplot(kmeans(df, 3), data = iris, label = TRUE)
 
 ```{r, message = FALSE}
 library(cluster)
-autoplot(clara(df, 3))
+autoplot(clara(USArrests, 3))
 ```
 
 Specifying `frame = TRUE` in `autoplot` for `stats::kmeans` and `cluster::*` draws convex for each cluster.
 
 ```{r}
-autoplot(fanny(df, 3), frame = TRUE)
+autoplot(fanny(USArrests, 3), frame = TRUE)
 ```
 
 If you want probability ellipse, `ggplot2` 1.0.0 or later is required. Specify whatever supported in [`ggplot2::stat_ellipse`](http://docs.ggplot2.org/dev/stat_ellipse.html)'s `type` keyword via `frame.type` option. 
 
 ```{r}
-autoplot(pam(df, 3), frame = TRUE, frame.type = 'norm')
+autoplot(pam(USArrests, 3), frame = TRUE, frame.type = 'norm')
 ```
 
 # Resources related to ggfortify

--- a/tests/testthat/test-base-infer.R
+++ b/tests/testthat/test-base-infer.R
@@ -8,44 +8,44 @@ test_that('infer works for MDS-likes', {
   expect_equal(infer(cmdscale(eurodist, x.ret = TRUE)), 'mds-like')
   library(MASS)
   expect_equal(infer(isoMDS(eurodist)), 'mds-like')
-  expect_equal(infer(sammon(eurodist)), 'mds-like')  
+  expect_equal(infer(sammon(eurodist)), 'mds-like')
 })
 
 test_that('fortify works for MDS-likes', {
   # MDS
   data(eurodist)
   fortified <- fortify(cmdscale(eurodist, eig = TRUE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(colnames(fortified), c('1', '2'))
   expect_equal(nrow(fortified), 21)
-  
+
   fortified <- fortify(cmdscale(eurodist, x.ret = TRUE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(colnames(fortified), c('1', '2'))
   expect_equal(nrow(fortified), 21)
-  
+
   fortified <- fortify(cmdscale(eurodist, k = 4, add = TRUE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(colnames(fortified), c('1', '2', '3', '4'))
   expect_equal(nrow(fortified), 21)
-  
+
   library(MASS)
   expect_equal(infer(isoMDS(eurodist)), 'mds-like')
   fortified <- fortify(cmdscale(eurodist, k = 3, add = TRUE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(colnames(fortified), c('1', '2', '3'))
   expect_equal(nrow(fortified), 21)
- 
+
   expect_equal(infer(sammon(eurodist)), 'mds-like')
   fortified <- fortify(cmdscale(eurodist, k = 3, add = TRUE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(colnames(fortified), c('1', '2', '3'))
-  expect_equal(nrow(fortified), 21) 
+  expect_equal(nrow(fortified), 21)
 })
 
 test_that('infer, fortify and autoplot works for dlm::dlmSmooth', {
   nile_fortified <- fortify(Nile)
-  
+
   library(dlm)
   form <- function(theta){
     dlm::dlmModPoly(order=1, dV=exp(theta[1]), dW=exp(theta[2]))
@@ -55,10 +55,10 @@ test_that('infer, fortify and autoplot works for dlm::dlmSmooth', {
   fortified <- fortify(filtered)
   expect_equal(colnames(fortified), c('Index', 'Data', 'Fitted', 'Residuals'))
   expect_equal(fortified$Index, nile_fortified$Index)
-  
-  smoothed <- dlm::dlmSmooth(filtered) 
+
+  smoothed <- dlm::dlmSmooth(filtered)
   expect_equal(infer(smoothed), 'dlmSmooth')
-  
+
   fortified <- fortify(smoothed)
   expect_equal(colnames(fortified), c('Index', 'Data'))
   expect_equal(fortified$Index, nile_fortified$Index)
@@ -69,30 +69,30 @@ test_that('infer, fortify and autoplot works for dlm::dlmSmooth', {
 
 test_that('infer, fortify and autoplot works for KFAS::signal', {
   nile_fortified <- fortify(Nile)
-  
+
   library(KFAS)
   model <- SSModel(
     Nile ~ SSMtrend(degree=1, Q=matrix(NA)), H=matrix(NA)
   )
   fit <- fitSSM(model=model, inits=c(log(var(Nile)),log(var(Nile))), method="BFGS")
-  
+
   smoothed <- KFS(fit$model)
   fortified <- fortify(smoothed)
   expect_equal(colnames(fortified), c('Index', 'Data', 'Fitted', 'Residuals'))
   expect_equal(fortified$Index, nile_fortified$Index)
-  
+
   filtered <- KFS(fit$model, filtering="mean", smoothing='none')
   fortified <- fortify(filtered)
   expect_equal(colnames(fortified), c('Index', 'Data', 'Fitted', 'Residuals'))
   expect_equal(fortified$Index, nile_fortified$Index)
-  
+
   trend <- signal(smoothed, states="trend")
   expect_equal(infer(trend), 'KFASSignal')
-  
+
   fortified <- fortify(trend)
   expect_equal(colnames(fortified), c('Index', 'Data'))
   expect_equal(fortified$Index, nile_fortified$Index)
-  
+
   autoplot(filtered)
   autoplot(smoothed)
   autoplot(trend)

--- a/tests/testthat/test-base.R
+++ b/tests/testthat/test-base.R
@@ -1,32 +1,32 @@
 context('test base')
 
 test_that('fortify.table works for Titanic', {
-  
+
   fortified <- ggplot2::fortify(Titanic)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
 
 })
 
 test_that('fortify.matrix works', {
-  
+
   m <- matrix(1:6, nrow=2, ncol=3)
   fortified <- ggplot2::fortify(m)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(colnames(fortified), c('1', '2', '3'))
   expect_equal(rownames(fortified), c('1', '2'))
-  
+
   fortified <- ggplot2::fortify(m, compat = TRUE)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(colnames(fortified), c('V1', 'V2', 'V3'))
   expect_equal(rownames(fortified), c('1', '2'))
-  
+
   m <- matrix(1:6, nrow=2, ncol=3)
   colnames(m) <- c('A', 'B', 'C')
   # dplyr doesn't guarantee rownames
   # rownames(m) <- c('X', 'Y')
-  
+
   fortified <- ggplot2::fortify(m)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(colnames(fortified), c('A', 'B', 'C'))
   # expect_equal(rownames(fortified), c('X', 'Y'))
 })

--- a/tests/testthat/test-changepoint.R
+++ b/tests/testthat/test-changepoint.R
@@ -7,7 +7,7 @@ test_that('fortify.cpt works for AirPassengers', {
 
   # mean
   fortified <- ggplot2::fortify(changepoint::cpt.mean(AirPassengers))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), c('Index', 'Data', 'mean'))
   expect_equal(fortified$Index[1], as.Date('1949-01-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1960-12-01'))
@@ -18,7 +18,7 @@ test_that('fortify.cpt works for AirPassengers', {
 
   # var
   fortified <- ggplot2::fortify(changepoint::cpt.var(AirPassengers))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), c('Index', 'Data', 'variance'))
   expect_equal(fortified$Index[1], as.Date('1949-01-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1960-12-01'))
@@ -29,7 +29,7 @@ test_that('fortify.cpt works for AirPassengers', {
 
   # meanvar
   fortified <- ggplot2::fortify(changepoint::cpt.meanvar(AirPassengers))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), c('Index', 'Data', 'mean', 'variance'))
   expect_equal(fortified$Index[1], as.Date('1949-01-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1960-12-01'))
@@ -45,7 +45,7 @@ test_that('fortify.breakpoints works for Nile', {
 
   bp.nile <- strucchange::breakpoints(Nile ~ 1)
   fortified <- ggplot2::fortify(bp.nile, is.date = TRUE)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), c('Index', 'Data', 'Breaks'))
   expect_equal(fortified$Index[1], as.Date('1871-01-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1970-01-01'))
@@ -55,7 +55,7 @@ test_that('fortify.breakpoints works for Nile', {
 
   bp.pts <- strucchange::breakpoints(bp.nile, breaks = 2)
   fortified <- ggplot2::fortify(bp.pts, is.date = TRUE)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), c('Index', 'Breaks'))
   expect_equal(fortified$Index[1], as.Date('1871-01-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1970-01-01'))
@@ -65,7 +65,7 @@ test_that('fortify.breakpoints works for Nile', {
   expect_equal(filtered$Index[nrow(filtered)], as.Date('1953-01-01'))
 
   fortified <- ggplot2::fortify(bp.pts, data = Nile, is.date = TRUE)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), c('Index', 'Data', 'Breaks'))
   expect_equal(fortified$Index[1], as.Date('1871-01-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1970-01-01'))

--- a/tests/testthat/test-cluster.R
+++ b/tests/testthat/test-cluster.R
@@ -4,50 +4,99 @@ test_that('fortify.kmeans works for iris', {
   df <- iris[-5]
 
   fortified <- ggplot2::fortify(stats::kmeans(df, 3))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  expect_equal(names(fortified), c('cluster'))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c('cluster'))
   expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
 
   fortified <- ggplot2::fortify(stats::kmeans(df, 3), data = iris)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  expect_equal(names(fortified), c('cluster', colnames(iris)))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(iris), 'cluster'))
   expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
 })
 
 test_that('fortify.partition works for iris', {
   df <- iris[-5]
-  expected_names <- c('cluster', colnames(df))
-
   # clara
   fortified <- ggplot2::fortify(cluster::clara(df, 3))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  expect_equal(names(fortified), expected_names)
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(df), 'cluster'))
   expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
 
   fortified <- ggplot2::fortify(cluster::clara(df, 3), data = iris)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  expect_equal(names(fortified), c(expected_names, 'Species'))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(iris), 'cluster'))
   expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
 
   # fanny
   fortified <- ggplot2::fortify(cluster::fanny(df, 3))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  expect_equal(names(fortified), expected_names)
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(df), 'cluster'))
   expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
 
   fortified <- ggplot2::fortify(cluster::fanny(df, 3), data = iris)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  expect_equal(names(fortified), c(expected_names, 'Species'))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(iris), 'cluster'))
   expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
 
   # pam
   fortified <- ggplot2::fortify(cluster::pam(df, 3))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  expect_equal(names(fortified), expected_names)
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(df), 'cluster'))
   expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
 
   fortified <- ggplot2::fortify(cluster::pam(df, 3), data = iris)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  expect_equal(names(fortified), c(expected_names, 'Species'))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(iris), 'cluster'))
   expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
+})
+
+test_that('fortify.partition works for USArrests', {
+  df <- USArrests
+
+  # clara
+  fortified <- ggplot2::fortify(cluster::clara(df, 3))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(df), 'cluster'))
+  expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
+
+  fortified <- ggplot2::fortify(cluster::clara(df, 3), data = USArrests)
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(df), 'cluster'))
+  expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
+
+  # fanny
+  fortified <- ggplot2::fortify(cluster::fanny(df, 3))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(df), 'cluster'))
+  expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
+
+  fortified <- ggplot2::fortify(cluster::fanny(df, 3), data = USArrests)
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(df), 'cluster'))
+  expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
+
+  # pam
+  fortified <- ggplot2::fortify(cluster::pam(df, 3))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(colnames(fortified), c(colnames(df), 'cluster'))
+  expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
+
+  fortified <- ggplot2::fortify(cluster::pam(df, 3), data = USArrests)
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(names(fortified), c(colnames(df), 'cluster'))
+  expect_equal(is.factor(fortified$cluster), TRUE)
+  expect_equal(rownames(fortified), rownames(df))
 })

--- a/tests/testthat/test-forecast.R
+++ b/tests/testthat/test-forecast.R
@@ -3,10 +3,10 @@ context('test forecast')
 test_that('fortify.forecast works for AirPassengers', {
   d.arima <- forecast::auto.arima(AirPassengers)
   d.forecast <- forecast::forecast(d.arima, level = c(95), h = 50)
-  
+
   fortified <- ggplot2::fortify(d.forecast)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
- 
+  expect_equal(is.data.frame(fortified), TRUE)
+
   expected_names <- c('Index', 'Data', 'Fitted',
                       'Point Forecast', 'Lo 95', 'Hi 95')
   expect_equal(names(fortified), expected_names)
@@ -16,62 +16,62 @@ test_that('fortify.forecast works for AirPassengers', {
   d.forecast <- forecast::forecast(d.arima, level = c(95, 80), h = 50)
   fortified <- ggplot2::fortify(d.forecast)
 
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), c(expected_names, 'Lo 80', 'Hi 80'))
   expect_equal(fortified$Index[1], as.Date('1949-01-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1965-02-01'))
-  
+
 })
 
 # ToDo: Check how to skip only on Travis-CI
 if (FALSE) {
 test_that('fortify.arfima works for austres', {
   fortified <- ggplot2::fortify(forecast::arfima(austres))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  
+  expect_equal(is.data.frame(fortified), TRUE)
+
   expected_names <- c('Index', 'Data', 'Fitted', 'Residuals')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.Date('1971-04-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1993-04-01'))
 
   fortified <- ggplot2::fortify(forecast::nnetar(austres))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  
+  expect_equal(is.data.frame(fortified), TRUE)
+
   expected_names <- c('Index', 'Data', 'Fitted', 'Residuals')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.Date('1971-04-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1993-04-01'))
 })
- 
+
 test_that('fortify.ets works for UKgas', {
   fortified <- ggplot2::fortify(forecast::ets(UKgas))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('Index', 'Data', 'Fitted', 'Residuals', 'Level', 'Slope', 'Season')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.Date('1960-01-01'))
-  expect_equal(fortified$Index[nrow(fortified)], as.Date('1986-10-01')) 
-  
+  expect_equal(fortified$Index[nrow(fortified)], as.Date('1986-10-01'))
+
   fortified <- ggplot2::fortify(forecast::bats(UKgas))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('Index', 'Data', 'Fitted', 'Residuals', 'Level', 'Slope', 'Season')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.Date('1960-01-01'))
-  expect_equal(fortified$Index[nrow(fortified)], as.Date('1986-10-01')) 
+  expect_equal(fortified$Index[nrow(fortified)], as.Date('1986-10-01'))
 })
 
 test_that('fortify.ets works for austres', {
   fortified <- ggplot2::fortify(forecast::ets(austres))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('Index', 'Data', 'Fitted', 'Residuals', 'Level', 'Slope', 'Season')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.Date('1971-04-01'))
-  expect_equal(fortified$Index[nrow(fortified)], as.Date('1993-04-01')) 
-  
+  expect_equal(fortified$Index[nrow(fortified)], as.Date('1993-04-01'))
+
   fortified <- ggplot2::fortify(forecast::bats(austres))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('Index', 'Data', 'Fitted', 'Residuals', 'Level', 'Slope')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.Date('1971-04-01'))
-  expect_equal(fortified$Index[nrow(fortified)], as.Date('1993-04-01')) 
+  expect_equal(fortified$Index[nrow(fortified)], as.Date('1993-04-01'))
 })
 }

--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -2,7 +2,7 @@ context('test stats')
 
 test_that('fortify.stl works for AirPassengers', {
   fortified <- ggplot2::fortify(stats::stl(AirPassengers, s.window = 'periodic'))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
 
   expected_names <- c('Index', 'Data', 'seasonal', 'trend', 'remainder')
   expect_equal(names(fortified), expected_names)
@@ -11,7 +11,7 @@ test_that('fortify.stl works for AirPassengers', {
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1960-12-01'))
 
   fortified <- ggplot2::fortify(stats::decompose(AirPassengers))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
 
   expected_names <- c('Index', 'Data', 'seasonal', 'trend', 'remainder')
   expect_equal(names(fortified), expected_names)
@@ -25,7 +25,7 @@ test_that('fortify.Arima works for AirPassengers', {
   library(ggfortify)
 
   fortified <- ggplot2::fortify(ar(AirPassengers))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('Index', 'Data', 'Fitted', 'Residuals')
   expect_equal(names(fortified), expected_names)
   expect_equal(as.vector(AirPassengers), as.vector(fortified[['Data']]))
@@ -40,7 +40,7 @@ test_that('fortify.Arima works for AirPassengers', {
   ggplot2::autoplot(m, data = AirPassengers)
 
   fortified <- ggplot2::fortify(stats::arima(AirPassengers))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('Index', 'Data', 'Fitted', 'Residuals')
   expect_equal(names(fortified), expected_names)
   expect_equal(as.vector(AirPassengers), as.vector(fortified[['Data']]))
@@ -56,7 +56,7 @@ test_that('fortify.Arima works for AirPassengers', {
   ggplot2::autoplot(m, data = AirPassengers)
 
   fortified <- ggplot2::fortify(stats::HoltWinters(AirPassengers))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
 
   expected_names <- c('Index', 'Data', 'xhat', 'level', 'trend', 'season', 'Residuals')
   expect_equal(names(fortified), expected_names)
@@ -77,31 +77,36 @@ test_that('fortify.prcomp works for iris', {
   expected_names <- c(names(df), pcs)
 
   fortified <- ggplot2::fortify(stats::prcomp(df, center = TRUE, scale = TRUE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), expected_names)
   expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), df)
+  expect_equal(rownames(fortified), rownames(df))
 
   fortified <- ggplot2::fortify(stats::prcomp(df, center = FALSE, scale = TRUE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), expected_names)
   expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), df)
+  expect_equal(rownames(fortified), rownames(df))
 
   fortified <- ggplot2::fortify(stats::prcomp(df, center = TRUE, scale = FALSE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), expected_names)
   expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), df)
+  expect_equal(rownames(fortified), rownames(df))
 
   fortified <- ggplot2::fortify(stats::prcomp(df, center = FALSE, scale = FALSE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), expected_names)
   expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), df)
+  expect_equal(rownames(fortified), rownames(df))
 
   # attach original
   expected_names <- c(names(df), 'Species', pcs)
   fortified <- ggplot2::fortify(stats::prcomp(df), data = iris)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), expected_names)
   expect_equal(data.frame(fortified[c(1, 2, 3, 4, 5)]), iris)
+  expect_equal(rownames(fortified), rownames(df))
 })
 
 test_that('fortify.princomp works for iris', {
@@ -110,31 +115,36 @@ test_that('fortify.princomp works for iris', {
   expected_names <- c(names(df), pcs)
 
   fortified <- ggplot2::fortify(stats::princomp(df, center = TRUE, scale = TRUE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), expected_names)
   expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), df)
+  expect_equal(rownames(fortified), rownames(df))
 
   fortified <- ggplot2::fortify(stats::princomp(df, center = FALSE, scale = TRUE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), expected_names)
   expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), df)
+  expect_equal(rownames(fortified), rownames(df))
 
   fortified <- ggplot2::fortify(stats::princomp(df, center = TRUE, scale = FALSE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), expected_names)
   expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), df)
+  expect_equal(rownames(fortified), rownames(df))
 
   fortified <- ggplot2::fortify(stats::princomp(df, center = FALSE, scale = FALSE))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), expected_names)
   expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), df)
+  expect_equal(rownames(fortified), rownames(df))
 
   # attach original
   expected_names <- c(names(df), 'Species', pcs)
   fortified <- ggplot2::fortify(stats::princomp(df), data = iris)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), expected_names)
   expect_equal(data.frame(fortified[c(1, 2, 3, 4, 5)]), iris)
+  expect_equal(rownames(fortified), rownames(df))
 })
 
 test_that('fortify.factanal works for state.x77', {
@@ -142,17 +152,91 @@ test_that('fortify.factanal works for state.x77', {
   pcs <- c('Factor1', 'Factor2', 'Factor3')
 
   fortified <- ggplot2::fortify(d.factanal)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), pcs)
+  expect_equal(rownames(fortified), rownames(state.x77))
 
   # attach original
   fortified <- ggplot2::fortify(d.factanal, data = state.x77)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(names(fortified), c(colnames(state.x77), pcs))
+  expect_equal(rownames(fortified), rownames(state.x77))
+})
+
+test_that('fortify.prcomp works for USArrests', {
+  pcs <- c('PC1', 'PC2', 'PC3', 'PC4')
+  expected_names <- c(names(USArrests), pcs)
+
+  fortified <- ggplot2::fortify(stats::prcomp(USArrests, center = TRUE, scale = TRUE))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(names(fortified), expected_names)
+  expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), USArrests)
+  expect_equal(rownames(fortified), rownames(USArrests))
+
+  fortified <- ggplot2::fortify(stats::prcomp(USArrests, center = FALSE, scale = TRUE))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(names(fortified), expected_names)
+  expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), USArrests)
+  expect_equal(rownames(fortified), rownames(USArrests))
+
+  fortified <- ggplot2::fortify(stats::prcomp(USArrests, center = TRUE, scale = FALSE))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(names(fortified), expected_names)
+  expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), USArrests)
+  expect_equal(rownames(fortified), rownames(USArrests))
+
+  fortified <- ggplot2::fortify(stats::prcomp(USArrests, center = FALSE, scale = FALSE))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(names(fortified), expected_names)
+  expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), USArrests)
+  expect_equal(rownames(fortified), rownames(USArrests))
+
+  # attach original
+  fortified <- ggplot2::fortify(stats::prcomp(USArrests), data = USArrests)
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(names(fortified), expected_names)
+  expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), USArrests)
+  expect_equal(rownames(fortified), rownames(USArrests))
+})
+
+test_that('fortify.princomp works for USArrests', {
+  pcs <- c('Comp.1', 'Comp.2', 'Comp.3', 'Comp.4')
+  expected_names <- c(names(USArrests), pcs)
+
+  fortified <- ggplot2::fortify(stats::princomp(USArrests, center = TRUE, scale = TRUE))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(names(fortified), expected_names)
+  expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), USArrests)
+  expect_equal(rownames(fortified), rownames(USArrests))
+
+  fortified <- ggplot2::fortify(stats::princomp(USArrests, center = FALSE, scale = TRUE))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(names(fortified), expected_names)
+  expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), USArrests)
+  expect_equal(rownames(fortified), rownames(USArrests))
+
+  fortified <- ggplot2::fortify(stats::princomp(USArrests, center = TRUE, scale = FALSE))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(names(fortified), expected_names)
+  expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), USArrests)
+  expect_equal(rownames(fortified), rownames(USArrests))
+
+  fortified <- ggplot2::fortify(stats::princomp(USArrests, center = FALSE, scale = FALSE))
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(names(fortified), expected_names)
+  expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), USArrests)
+  expect_equal(rownames(fortified), rownames(USArrests))
+
+  # attach original
+  fortified <- ggplot2::fortify(stats::princomp(USArrests), data = USArrests)
+  expect_equal(is.data.frame(fortified), TRUE)
+  expect_equal(names(fortified), expected_names)
+  expect_equal(data.frame(fortified[c(1, 2, 3, 4)]), USArrests)
+  expect_equal(rownames(fortified), rownames(USArrests))
 })
 
 test_that('fortify.dist works for eurodist', {
   fortified <- ggplot2::fortify(eurodist)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(dim(fortified), c(21, 21))
 })

--- a/tests/testthat/test-surv.R
+++ b/tests/testthat/test-surv.R
@@ -6,9 +6,9 @@ test_that('fortify.survfit works for survival::lung', {
   d.survfit <- survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung)
   fortified <- ggplot2::fortify(d.survfit)
 
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('time', 'n.risk', 'n.event', 'n.censor', 'surv',
-                      'std.err', 'upper', 'lower', 'strata') 
+                      'std.err', 'upper', 'lower', 'strata')
   expect_equal(names(fortified), expected_names)
 })
 
@@ -16,8 +16,8 @@ test_that('fortify.survfit.cox works for survival::lung', {
   d.coxph <- survival::coxph(survival::Surv(time, status) ~ sex, data = survival::lung)
   fortified <- ggplot2::fortify(survival::survfit(d.coxph))
 
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('time', 'n.risk', 'n.event', 'n.censor', 'surv',
-                      'std.err', 'upper', 'lower', 'cumhaz') 
+                      'std.err', 'upper', 'lower', 'cumhaz')
   expect_equal(names(fortified), expected_names)
 })

--- a/tests/testthat/test-ts.R
+++ b/tests/testthat/test-ts.R
@@ -5,15 +5,15 @@ context('test timeseries')
 
 test_that('fortify.ts works for AirPassengers', {
   fortified <- ggplot2::fortify(AirPassengers)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  
+  expect_equal(is.data.frame(fortified), TRUE)
+
   expected_names <- c('Index', 'Data')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.Date('1949-01-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1960-12-01'))
-  
+
   fortified <- ggplot2::fortify(AirPassengers, index.name = 'time', data.name = 'orig')
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('time', 'orig')
   expect_equal(names(fortified), expected_names)
 })
@@ -21,31 +21,31 @@ test_that('fortify.ts works for AirPassengers', {
 test_that('fortify.ts works for Canada', {
   data(Canada, package = 'vars')
   fortified <- ggplot2::fortify(Canada)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  
+  expect_equal(is.data.frame(fortified), TRUE)
+
   expected_names <- c('Index', 'e', 'prod', 'rw', 'U')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.Date('1980-01-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('2000-10-01'))
-  
+
   # In multivariate, data.name will not be applied
   fortified <- ggplot2::fortify(Canada, index.name = 'time', data.name = 'orig')
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('time', 'e', 'prod', 'rw', 'U')
   expect_equal(names(fortified), expected_names)
 })
 
 test_that('fortify.timeSeries works for AirPassengers', {
   fortified <- ggplot2::fortify(timeSeries::as.timeSeries(AirPassengers))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  
+  expect_equal(is.data.frame(fortified), TRUE)
+
   expected_names <- c('Index', 'Data')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.POSIXct('1949-01-31'))
   expect_equal(fortified$Index[nrow(fortified)], as.POSIXct('1960-12-31'))
-  
+
   fortified <- ggplot2::fortify(AirPassengers, index.name = 'time', data.name = 'orig')
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('time', 'orig')
   expect_equal(names(fortified), expected_names)
 })
@@ -53,15 +53,15 @@ test_that('fortify.timeSeries works for AirPassengers', {
 test_that('fortify.timeSeries works for Canada', {
   data(Canada, package = 'vars')
   fortified <- ggplot2::fortify(timeSeries::as.timeSeries(Canada))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
-  
+  expect_equal(is.data.frame(fortified), TRUE)
+
   expected_names <- c('Index', 'e', 'prod', 'rw', 'U')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.POSIXct('1980-03-31'))
   expect_equal(fortified$Index[nrow(fortified)], as.POSIXct('2000-12-31'))
-  
+
   fortified <- ggplot2::fortify(Canada, index.name = 'time')
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expected_names <- c('time', 'e', 'prod', 'rw', 'U')
   expect_equal(names(fortified), expected_names)
 })

--- a/tests/testthat/test-vars.R
+++ b/tests/testthat/test-vars.R
@@ -6,11 +6,11 @@ test_that('vars.varored works for Canada', {
   data(Canada, package = 'vars')
   d.vselect <- vars::VARselect(Canada, lag.max = 5, type = 'const')$selection[1]
   d.var <- vars::VAR(Canada, p = d.vselect, type = 'const')
-  
+
   fortified <- ggplot2::fortify(stats::predict(d.var, n.ahead = 50))
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(nrow(fortified), 50 + nrow(Canada))
-  
+
   expected_names <- c('Index', 'e', 'prod', 'rw', 'U',
                       'e.fcst', 'e.lower', 'e.upper', 'e.CI',
                       'prod.fcst', 'prod.lower', 'prod.upper', 'prod.CI',
@@ -19,11 +19,11 @@ test_that('vars.varored works for Canada', {
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.Date('1980-01-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('2013-04-01'))
-  
+
   fortified <- ggplot2::fortify(stats::predict(d.var, n.ahead = 50), melt = TRUE)
-  expect_equal(is(fortified, 'tbl_df'), TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
   expect_equal(nrow(fortified), (50 + nrow(Canada)) * 4)
-  
+
   expected_names <- c('Index', 'Data', 'fcst', 'lower', 'upper', 'CI', 'variable')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.Date('1980-01-01'))


### PR DESCRIPTION
Closes #20, Closes #7.

The issue was caused by a spec change performed in {dplyr} 0.4 which no longer returns `rownames`.

http://blog.rstudio.org/2015/01/09/dplyr-0-4-0/
> dplyr never prints row names since no dplyr method is guaranteed to preserve them:

Following classes are affected, and all of them should be fixed now.

- `prcomp`, `princomp`
- `kmeans`, `clara`, `fanny`, `pem`
- `matrix`, `cmdscale`, `isoMDS`, `sammon`
- `lm`, `glm`

```
autoplot(prcomp(USArrests, scale = TRUE), label = TRUE)
```
![rplot](https://cloud.githubusercontent.com/assets/1696302/6105470/b1e7af4e-b09a-11e4-9899-9ad077f21b36.png)

Ref: http://stackoverflow.com/questions/28395517/reproducing-statsbiplot-with-ggplot2autoplot-from-ggfortify-r-package