### PR TITLE
ENH: ggfreqplot supports facet.labeller

### DIFF
--- a/R/tslib.R
+++ b/R/tslib.R
@@ -361,6 +361,7 @@ gglagplot <- function(ts, lags = 1, nrow = NULL, ncol = NULL) {
 #' @param ncol Number of plot columns
 #' @inheritParams plot_confint
 #' @param conf.int.value Coverage probability for confidence interval
+#' @param facet.labeller A vector used as facet labels
 #' @param ... Keywords passed to autoplot.ts
 #' @return ggplot
 #' @examples
@@ -373,7 +374,7 @@ ggfreqplot <- function(data, freq = NULL,
                        conf.int = FALSE,
                        conf.int.colour = '#0000FF', conf.int.linetype = 'dashed',
                        conf.int.fill = NULL, conf.int.alpha = 0.3,
-                       conf.int.value = 0.95,
+                       conf.int.value = 0.95, facet.labeller = NULL,
                        ...) {
   is.univariate(data)
 
@@ -386,7 +387,14 @@ ggfreqplot <- function(data, freq = NULL,
   }
 
   d <- ggplot2::fortify(data)
-  freqd <- data.frame(Frequency = rep(1:freq, length.out = length(data)))
+  if (is.null(facet.labeller)) {
+    freqs <- 1:freq
+  } else if (length(facet.labeller)  == freq) {
+    freqs <- factor(facet.labeller, levels = facet.labeller)
+  } else {
+    stop('facet.labeller must be a vector which has the same length as freq')
+  }
+  freqd <- data.frame(Frequency = rep(freqs, length.out = length(data)))
   d <- cbind(d, freqd)
 
   summarised <- dplyr::group_by_(d, 'Frequency') %>%

--- a/man/ggfreqplot.Rd
+++ b/man/ggfreqplot.Rd
@@ -7,7 +7,7 @@
 ggfreqplot(data, freq = NULL, nrow = NULL, ncol = NULL,
   conf.int = FALSE, conf.int.colour = "#0000FF",
   conf.int.linetype = "dashed", conf.int.fill = NULL,
-  conf.int.alpha = 0.3, conf.int.value = 0.95, ...)
+  conf.int.alpha = 0.3, conf.int.value = 0.95, facet.labeller = NULL, ...)
 }
 \arguments{
 \item{data}{\code{stats::ts} instance}

--- a/tests/testthat/test-tslib.R
+++ b/tests/testthat/test-tslib.R
@@ -24,11 +24,11 @@ test_that('get.dtindex works for Nile', {
   result <- ggfortify:::get.dtindex(Nile)
   expect_equal(result[1], 1871)
   expect_equal(result[length(result)], 1970)
-  
+
   result <- ggfortify:::get.dtindex(Nile, is.date = FALSE)
   expect_equal(result[1], 1871)
   expect_equal(result[length(result)], 1970)
-  
+
   result <- ggfortify:::get.dtindex(Nile, is.date = TRUE)
   expect_equal(result[1], as.Date('1871-01-01'))
   expect_equal(result[length(result)], as.Date('1970-01-01'))
@@ -49,7 +49,7 @@ test_that('get.dtindex.continuous works for UKgas', {
 test_that('confint.acf works for AirPassengers', {
   result <- ggfortify:::confint.acf(stats::acf(AirPassengers, plot = FALSE))
   expect_equal(result, 0.1633303, tolerance = .000001)
-  
+
   result <- ggfortify:::confint.acf(stats::acf(AirPassengers, plot = FALSE), ci.type = 'ma')
   expected <- c(NA, 0.1633303, 0.2731862, 0.3399018, 0.3876238, 0.4248224, 0.4556929,
                 0.4821335, 0.5058641, 0.5280447, 0.5503176, 0.5737563, 0.5988899,
@@ -57,14 +57,14 @@ test_that('confint.acf works for AirPassengers', {
                 0.7054849, 0.7130967, 0.7203560)
   expect_equal(result, expected, tolerance = .000001)
 })
-       
+
 test_that('fitted/residuals works for Arima/ar', {
   m <- stats::ar(UKgas)
   resid <- residuals(m)
   testthat::expect_false(is.null(resid))
   fit <- fitted(m)
   testthat::expect_false(is.null(fitted))
-  
+
   original <- as.vector(UKgas)[7:length(UKgas)]
   calcurated <- as.vector(fit + resid)[7:length(UKgas)]
   testthat::expect_equal(original, calcurated)
@@ -74,8 +74,13 @@ test_that('fitted/residuals works for Arima/ar', {
   testthat::expect_false(is.null(resid))
   fit <- fitted(m)
   testthat::expect_false(is.null(fitted))
-  
+
   original <- as.vector(UKgas)[7:length(UKgas)]
   calcurated <- as.vector(fit + resid)[7:length(UKgas)]
   testthat::expect_equal(original, calcurated)
+})
+
+test_that('ggfreqplot', {
+  p <- ggfreqplot(AirPassengers)
+  p <- ggfreqplot(AirPassengers, facet.labeller = c(3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2))
 })


### PR DESCRIPTION
Currently, ``ggfreqplot`` automatically use facet labels starting from 1. However, time-series can start from a different month.

The fix intends to add ``facet.labeller`` keyword to control facet labels. ``labeller`` keyword is derived from ``ggplot2::facet_grid``. See http://www.cookbook-r.com/Graphs/Facets_%28ggplot2%29/

However, there are 2 problems:

-  ``ggfreqplot`` internally uses ``facet_wraps`` which doesn't support ``labeller`` kw, or any other direct way to change labels. Thus, we have to change original data to control labels [(for now)](https://github.com/hadley/ggplot2/pull/1127). 
- When we change original data used for facet, facets are automatically ordered by name. You can see following plots are categorized according to ``facet.labeller`` from line shapes, but the latter example is expected to start from 4?

```
ggfreqplot(AirPassengers, ncol = 6)
```

![rplot01](https://cloud.githubusercontent.com/assets/1696302/8271870/c1abd000-1868-11e5-8928-df22881813b5.png)

```
ggfreqplot(AirPassengers, facet.labeller = c(4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3), ncol = 6)
```
*removed*

