### PR TITLE
BUG: unable to autoplot varpred

### DIFF
--- a/R/base_fortify_ts.R
+++ b/R/base_fortify_ts.R
@@ -198,7 +198,9 @@ autoplot.ts <- function(object, columns = NULL, group = NULL,
   if (is(ts.column, 'yearmon') || is(ts.column, 'yearqtr')) {
     plot.data[[index.name]] <- zoo::as.Date(plot.data[[index.name]])
   }
-  plot.data <- tidyr::gather_(plot.data, 'variable', 'value', columns)
+
+  group_key = 'plot_group'
+  plot.data <- tidyr::gather_(plot.data, group_key, 'value', columns)
 
   # create ggplot instance if not passed
   if (is.null(p)) {
@@ -230,18 +232,18 @@ autoplot.ts <- function(object, columns = NULL, group = NULL,
   }
 
   if (facets) {
-    args['group'] <- 'variable'
+    args['group'] <- group_key
     p <- p + do.call(geom_factory, args)
-    p <- apply_facets(p, ~ variable, nrow = nrow, ncol = ncol, scales = scales)
+    p <- apply_facets(p, ~ plot_group, nrow = nrow, ncol = ncol, scales = scales)
   } else {
     if (!.is.univariate) {
       # ts.colour cannot be used
       if (!is.null(colour)) {
         warning('multivariate timeseries with facets=FALSE are colorized by variable, colour is ignored')
       }
-      args['colour'] <- 'variable'
+      args['colour'] <- group_key
       if (geom %in% c('bar', 'ribbon')) {
-        args['fill'] <- 'variable'
+        args['fill'] <- group_key
       }
       if (geom == 'ribbon' && !stacked && is.null(alpha)) {
         args['alpha'] <- 0.5

--- a/R/fortify_vars.R
+++ b/R/fortify_vars.R
@@ -71,6 +71,7 @@ autoplot.varprd <- function(object, is.date = NULL, ts.connect = TRUE,
                             conf.int.colour = '#0000FF', conf.int.linetype = 'none',
                             conf.int.fill = '#000000', conf.int.alpha = 0.3,
                             ...) {
+
   plot.data <- ggplot2::fortify(object, is.date = is.date,
                                 ts.connect = ts.connect, melt = TRUE)
 
@@ -79,6 +80,7 @@ autoplot.varprd <- function(object, is.date = NULL, ts.connect = TRUE,
   predict.data <- dplyr::filter_(plot.data, '!is.na(fcst)')
 
   p <- autoplot.ts(original.data, columns = 'Data', ...)
+
   p <- autoplot.ts(predict.data, columns = 'fcst', p = p,
                    geom = predict.geom,
                    colour = predict.colour, size = predict.size,

--- a/man/ggmultiplot-class.Rd
+++ b/man/ggmultiplot-class.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/plotlib.R
 \docType{class}
 \name{ggmultiplot-class}
-\alias{[,ggmultiplot,ANY,ANY-method}
 \alias{[,ggmultiplot-method}
 \alias{[<-,ggmultiplot-method}
 \alias{[[,ggmultiplot-method}
@@ -13,7 +12,7 @@
 \usage{
 \S4method{length}{ggmultiplot}(x)
 
-\S4method{[}{ggmultiplot,ANY,ANY}(x, i, j, ..., drop = TRUE)
+\S4method{[}{ggmultiplot}(x, i, j, ..., drop = TRUE)
 
 \S4method{[[}{ggmultiplot}(x, i, j, ..., drop)
 

--- a/tests/testthat/test-vars.R
+++ b/tests/testthat/test-vars.R
@@ -2,7 +2,7 @@ library(vars)
 
 context('test vars')
 
-test_that('vars.varored works for Canada', {
+test_that('vars.varpred works for Canada', {
   data(Canada, package = 'vars')
   d.vselect <- vars::VARselect(Canada, lag.max = 5, type = 'const')$selection[1]
   d.var <- vars::VAR(Canada, p = d.vselect, type = 'const')
@@ -36,4 +36,17 @@ test_that('vars.varored works for Canada', {
   expect_equal(fortified$Index[1], as.Date('1980-01-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('2013-04-01'))
 
+})
+
+test_that('autoplot works for Canada', {
+  data(Canada, package = 'vars')
+  d.vselect <- VARselect(Canada, lag.max = 5, type = 'const')$selection[1]
+  d.var <- VAR(Canada, p = d.vselect, type = 'const')
+
+  p <- autoplot(predict(d.var, n.ahead = 50))
+  expect_true(is(p, 'ggplot'))
+
+  p <- autoplot(predict(d.var, n.ahead = 50), ts.colour = 'dodgerblue4',
+                predict.colour = 'blue', predict.linetype = 'dashed')
+  expect_true(is(p, 'ggplot'))
 })


### PR DESCRIPTION
Fixed the below error.

```
library(vars)
data(Canada)
d.vselect <- VARselect(Canada, lag.max = 5, type = 'const')$selection[1]
d.var <- VAR(Canada, p = d.vselect, type = 'const')
autoplot(predict(d.var, n.ahead = 50), ts.colour = 'dodgerblue4',
         predict.colour = 'blue', predict.linetype = 'dashed')
#  エラー: Each variable must have a unique name. Problem variables: 'variable'
```