### PR TITLE
Added option to plot different components of prcomp and the like

### DIFF
--- a/R/fortify_stats.R
+++ b/R/fortify_stats.R
@@ -212,6 +212,7 @@ fortify.lfda <- function(model, data = NULL, ...) {
 #' @param object PCA-like instance
 #' @param data Joined to fitting result if provided.
 #' @param scale scaling parameter, disabled by 0
+#' @param x y principal component number used in x and y axis
 #' @param ... other arguments passed to \code{ggbiplot}
 #' @inheritParams ggbiplot
 #' @inheritParams plot_label
@@ -239,35 +240,40 @@ fortify.lfda <- function(model, data = NULL, ...) {
 #' autoplot(d.factanal, label = TRUE, loadings = TRUE, loadings.label = TRUE)
 #' @export
 autoplot.pca_common <- function(object, data = NULL,
-                                scale = 1.0, ...) {
+                                scale = 1.0, x = 1, y = 2, ...) {
 
   plot.data <- ggplot2::fortify(object, data = data)
   plot.data$rownames <- rownames(plot.data)
 
   if (is_derived_from(object, 'prcomp')) {
-    x.column <- 'PC1'
-    y.column <- 'PC2'
+
+    PC <- paste0("PC", c(x, y))
+    x.column <- PC[1]
+    y.column <- PC[2]
     loadings.column <- 'rotation'
 
     lam <- object$sdev[1L:2L]
     lam <- lam * sqrt(nrow(plot.data))
 
   } else if (is_derived_from(object, 'princomp')) {
-    x.column <- 'Comp.1'
-    y.column <- 'Comp.2'
+    PC <- paste0("Comp.", c(x, y))
+    x.column <- PC[1]
+    y.column <- PC[2]
     loadings.column <- 'loadings'
 
     lam <- object$sdev[1L:2L]
     lam <- lam * sqrt(nrow(plot.data))
 
   } else if (is_derived_from(object, 'factanal')) {
-    x.column <- 'Factor1'
-    y.column <- 'Factor2'
+    PC <- paste0("Factor", c(x, y))
+    x.column <- PC[1]
+    y.column <- PC[2]
     scale <- 0
     loadings.column <- 'loadings'
   } else if (is_derived_from(object, 'lfda')) {
-    x.column <- 'PC1'
-    y.column <- 'PC2'
+    PC <- paste0("PC", c(x, y))
+    x.column <- PC[1]
+    y.column <- PC[2]
     scale <- 0
     loadings.column <- NULL
   } else {

--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -476,6 +476,52 @@ test_that('autoplot.princomp works for iris', {
 
 })
 
+test_that('autoplot.prcomp plots the desired components', {
+
+  obj <- stats::prcomp(iris[-5])
+
+  exp_x <- c(-0.0126825223275179, 0.00702830726589863, 0.00575560482235143,
+             0.0126389126842801, -0.0129746622747112, -0.0294365091522609)
+  exp_y <- c(0.00462679871185076, 0.0348838201207289, -0.00296691364551725,
+             -0.00523087125212831, -0.0149303631846485, -0.0279578145062899
+  )
+
+  p <- ggplot2::autoplot(obj, x = 2, y = 3)
+  expect_true(is(p, 'ggplot'))
+  expect_equal(length(p$layers), 1)
+  expect_true('GeomPoint' %in% class(p$layers[[1]]$geom))
+  ld <- head(ggplot2:::layer_data(p, 1))
+  expect_equal(ld$x, exp_x, tolerance = 1e-4)
+  expect_equal(ld$y, exp_y, tolerance = 1e-4)
+  expect_equal(ld$colour, rep('black', 6))
+  expect_equal(p$labels$x, "PC2")
+  expect_equal(p$labels$y, "PC3")
+
+})
+
+test_that('autoplot.princomp plots the desired components', {
+
+  obj <- stats::princomp(iris[-5])
+
+  exp_x <- c(-0.0126825223275179, 0.00702830726589863, 0.00575560482235143,
+             0.0126389126842801, -0.0129746622747112, -0.0294365091522609)
+  exp_y <- c(-0.00464229891845705, -0.0350006841670721, 0.00297685308255621,
+             0.00524839515800552, 0.014980381291871, 0.0280514757887639)
+
+
+  p <- ggplot2::autoplot(obj, x = 2, y = 3)
+  expect_true(is(p, 'ggplot'))
+  expect_equal(length(p$layers), 1)
+  expect_true('GeomPoint' %in% class(p$layers[[1]]$geom))
+  ld <- head(ggplot2:::layer_data(p, 1))
+  expect_equal(ld$x, exp_x, tolerance = 1e-4)
+  expect_equal(ld$y, exp_y, tolerance = 1e-4)
+  expect_equal(ld$colour, rep('black', 6))
+  expect_equal(p$labels$x, "Comp.2")
+  expect_equal(p$labels$y, "Comp.3")
+
+})
+
 test_that('autoplot.factanal works for state.x77', {
 
   obj <- stats::factanal(state.x77, factors = 3, scores = 'regression')
@@ -491,6 +537,19 @@ test_that('autoplot.factanal works for state.x77', {
   expect_true('GeomPoint' %in% class(p$layers[[1]]$geom))
   expect_true('GeomText' %in% class(p$layers[[2]]$geom))
 
+})
+
+
+test_that('autoplot.factanal plots the desired components', {
+
+  obj <- stats::factanal(state.x77, factors = 3, scores = 'regression')
+
+  p <- ggplot2::autoplot(obj, x = 2, y = 3)
+  expect_true(is(p, 'ggplot'))
+  expect_equal(length(p$layers), 1)
+  expect_true('GeomPoint' %in% class(p$layers[[1]]$geom))
+  expect_equal(p$labels$x, "Factor2")
+  expect_equal(p$labels$y, "Factor3")
 })
 
 test_that('fortify.dist works for eurodist', {


### PR DESCRIPTION
I added the functionality to choose the components to plot. Defaults to x = 1, y = 2

Some examples:
```
autoplot(stats::princomp(iris[-5]))
autoplot(stats::princomp(iris[-5]), x = 2, y = 3)
autoplot(stats::prcomp(iris[-5]))
autoplot(stats::prcomp(iris[-5]), x = 2, y = 3)
d.factanal <- stats::factanal(state.x77, factors = 3, scores = 'regression')
autoplot(d.factanal)
autoplot(d.factanal, x = 2, y = 3)
autoplot(cluster::clara(iris[-5], 3), label = TRUE)
autoplot(cluster::clara(iris[-5], 3), label = TRUE, x = 1, y = 2)
autoplot(cluster::clara(iris[-5], 3), label = TRUE, x = 1, y = 3)
```

This closes #144 