### PR TITLE
TST: allow failures of dev build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ env:
   - PKG=DEV
   - PKG=STD
 
+matrix:
+  allow_failures:
+    - env: PKG=DEV
+
 r_binary_packages:
   - dplyr
   - tidyr

--- a/man/autoplot.survfit.Rd
+++ b/man/autoplot.survfit.Rd
@@ -21,7 +21,7 @@
 
 \item{fun}{an arbitrary function defining a transformation of the survival curve}
 
-\item{surv.geom}{geometric string for survival curve. 'step' or line'}
+\item{surv.geom}{geometric string for survival curve. 'step', 'line' or 'point'}
 
 \item{surv.colour}{line colour for survival curve}
 


### PR DESCRIPTION
Closes #159. This looks to be caused by dev build related `rlang` change. Allow failures ATM.