### PR TITLE
autoplot.survfit(): fix to handling arbitrary functions

### DIFF
--- a/R/fortify_surv.R
+++ b/R/fortify_surv.R
@@ -223,7 +223,7 @@ autoplot.survfit <- function(object, fun = NULL,
       }
     }
 
-    if (is.null(fun) || fun %in% c('identity', 'event')) {
+    if (is.null(fun) || identical(fun, 'identity') || identical(fun, 'event')) {
       scale_labels <- scales::percent
     } else {
       scale_labels <- ggplot2::waiver()

--- a/tests/testthat/test-surv.R
+++ b/tests/testthat/test-surv.R
@@ -30,6 +30,9 @@ test_that('fortify.survfit works for lung', {
   p <- ggplot2::autoplot(d.survfit, fun = 'event')
   expect_true(is(p, 'ggplot'))
 
+  p <- ggplot2::autoplot(d.survfit, fun = function(x) { 1-x })
+  expect_true(is(p, 'ggplot'))
+
   fortified <- ggplot2::fortify(d.survfit, surv.connect = TRUE)
   expect_true(is.data.frame(fortified))
   expected_names <- c('time', 'n.risk', 'n.event', 'n.censor', 'surv',


### PR DESCRIPTION
`fun %in% x`  fails if `fun` is a function