### PR TITLE
Updated forecast.ets unit test to be robust to changes in model selected

### DIFF
--- a/tests/testthat/test-forecast.R
+++ b/tests/testthat/test-forecast.R
@@ -87,7 +87,10 @@ test_that('fortify.ets works for austres', {
   result <- forecast::ets(austres)
   fortified <- ggplot2::fortify(result)
   expect_equal(is.data.frame(fortified), TRUE)
-  expected_names <- c('Index', 'Data', 'Fitted', 'Residuals', 'Level', 'Slope')
+  if(result$components[3] == "N")
+    expected_names <- c('Index', 'Data', 'Fitted', 'Residuals', 'Level', 'Slope')
+  else
+    expected_names <- c('Index', 'Data', 'Fitted', 'Residuals', 'Level', 'Slope', 'Season')
   expect_equal(names(fortified), expected_names)
   expect_equal(fortified$Index[1], as.Date('1971-04-01'))
   expect_equal(fortified$Index[nrow(fortified)], as.Date('1993-04-01'))


### PR DESCRIPTION
This should work with both v8.2 and v8.3 of the forecast package.