### PR TITLE
remove class from model residuals in autoplot.lm()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,4 +67,4 @@ Suggests:
     xts,
     zoo,
     lfda
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/R/fortify_stats_lm.R
+++ b/R/fortify_stats_lm.R
@@ -56,6 +56,10 @@ autoplot.lm <- function(object, which = c(1:3, 5), data = NULL,
   show <- rep(FALSE, 6)
   show[which] <- TRUE
 
+  # ggplot2 can't rescale residuals with type AsIs
+  # See https://github.com/sinhrks/ggfortify/issues/202
+  class(object$residuals) <- NULL
+
   if (is.null(data)) {
     # ggplot2::fortify can't handle NULL properly
     plot.data <- ggplot2::fortify(object)

--- a/tests/testthat/test-stats-lm.R
+++ b/tests/testthat/test-stats-lm.R
@@ -565,3 +565,15 @@ test_that('autoplot.lm can be used in ggsave()', {
   expect_true(file.exists('temp.png'))
   unlink('temp.png')
 })
+
+test_that('fortify.lm works with AsIs response', {
+  skip_on_cran()
+  skip_on_travis()
+  mdl_cars <- lm(I(dist ^ 2) ~ speed, data = cars)
+  p <- autoplot(mdl_cars, which = 1:6)
+  expect_true(is(p, 'ggmultiplot'))
+  # Previous problems occured when printing, so write to file
+  ggsave(p, file='temp-test-AsIs.png', h = 6, w = 6, units = "in", dpi = 50)
+  expect_true(file.exists('temp-test-AsIs.png'))
+  unlink('temp-test-AsIs.png')
+})


### PR DESCRIPTION
Fixes https://github.com/sinhrks/ggfortify/issues/202

I see some test errors unrelated to this fix (mostly around building vignettes).