### PR TITLE
Updating many files to address dplyr XXX_() variants being deprecated

### DIFF
--- a/R/base_fortify_ts.R
+++ b/R/base_fortify_ts.R
@@ -202,7 +202,7 @@ autoplot.ts <- function(object, columns = NULL, group = NULL,
   }
 
   group_key <- 'plot_group'
-  plot.data <- tidyr::gather_(plot.data, group_key, 'value', columns)
+  plot.data <- tidyr::pivot_longer(plot.data, names_to=group_key, values_to='value', columns)
 
   # create ggplot instance if not passed
   if (is.null(p)) {

--- a/R/base_fortify_ts.R
+++ b/R/base_fortify_ts.R
@@ -201,8 +201,9 @@ autoplot.ts <- function(object, columns = NULL, group = NULL,
     plot.data[[index.name]] <- zoo::as.Date(plot.data[[index.name]])
   }
 
-  group_key <- 'plot_group'
-  plot.data <- tidyr::pivot_longer(plot.data, names_to=group_key, values_to='value', columns)
+  group_key <- 'plot_group'  # gets used later. Don't know why its defined here.
+  plot.data <- tidyr::pivot_longer(plot.data, names_to=group_key, values_to='value', columns) %>%
+    arrange(plot_group)      # somewhere later the sort order matters.
 
   # create ggplot instance if not passed
   if (is.null(p)) {

--- a/R/fortify_basis.R
+++ b/R/fortify_basis.R
@@ -56,7 +56,7 @@ fortify.basis <- function(model, data, n=256, ...) {
         data <- seq(from=bounds[1], to=bounds[2], length.out=n + 1)
     }
     predict(model, data) %>%
-        dplyr::as_tibble %>%
+        dplyr::as_tibble() %>%
         dplyr::mutate(x=data) %>%
         tidyr::pivot_longer(colnames(model), names_to="Spline", values_to="y") %>%
         dplyr::arrange(Spline, x) %>%

--- a/R/fortify_basis.R
+++ b/R/fortify_basis.R
@@ -55,9 +55,9 @@ fortify.basis <- function(model, data, n=256, ...) {
         ## Add 1 to length.out because both endpoints are included
         data <- seq(from=bounds[1], to=bounds[2], length.out=n + 1)
     }
-    out <- predict(model, data) %>%
-        as_tibble %>%
-        mutate(x=data) %>%
+    predict(model, data) %>%
+        dplyr::as_tibble %>%
+        dplyr::mutate(x=data) %>%
         tidyr::pivot_longer(colnames(model), names_to="Spline", values_to="y") %>%
         dplyr::arrange(Spline, x) %>%
         dplyr::select(Spline, x, y)

--- a/R/fortify_basis.R
+++ b/R/fortify_basis.R
@@ -55,11 +55,12 @@ fortify.basis <- function(model, data, n=256, ...) {
         ## Add 1 to length.out because both endpoints are included
         data <- seq(from=bounds[1], to=bounds[2], length.out=n + 1)
     }
-    predict(model, data) %>%
+    out <- predict(model, data) %>%
         as_tibble %>%
         mutate(x=data) %>%
-        gather_(key_col="Spline", value_col="y", gather_cols=colnames(model)) %>%
-        select_("Spline", "x", "y")
+        tidyr::pivot_longer(colnames(model), names_to="Spline", values_to="y") %>%
+        dplyr::arrange(Spline, x) %>%
+        dplyr::select(Spline, x, y)
 }
 
 #' Autoplot spline basis instances

--- a/R/fortify_changepoint.R
+++ b/R/fortify_changepoint.R
@@ -85,7 +85,7 @@ autoplot.cpt <- function(object, is.date = NULL,
                                  colour = cpt.colour, linetype = cpt.linetype)
   }
   if ('variance' %in% names(plot.data)) {
-    d <- dplyr::filter_(plot.data, '!is.na(variance)')
+    d <- dplyr::filter(plot.data, !is.na(variance))
     p <- p + ggplot2::geom_vline(xintercept = as.integer(d$Index),
                                  colour = cpt.colour, linetype = cpt.linetype)
   }
@@ -119,7 +119,7 @@ autoplot.breakpoints <- function(object, data = NULL,
     stop("'data' is mandatory for plotting breakpoints instance")
   }
 
-  d <- dplyr::filter_(plot.data, '!is.na(Breaks)')
+  d <- dplyr::filter(plot.data, !is.na(Breaks))
   p <- p + ggplot2::geom_vline(xintercept = as.integer(d$Index),
                                colour = cpt.colour, linetype = cpt.linetype)
   p

--- a/R/fortify_cluster.R
+++ b/R/fortify_cluster.R
@@ -57,8 +57,7 @@ autoplot.kmeans <- function(object, data = NULL,
   plot.data <- ggplot2::fortify(object, data = data)
   dots <- colnames(object[[dots]])
   plot.data$rownames <- rownames(plot.data)
-
-  pca.data <- dplyr::select_(plot.data, .dots = dots)
+  pca.data <- dplyr::select(plot.data, all_of(dots))
   p <- ggplot2::autoplot(stats::prcomp(pca.data), data = plot.data,
                          colour = colour, ...)
   p

--- a/R/fortify_forecast.R
+++ b/R/fortify_forecast.R
@@ -65,8 +65,8 @@ autoplot.forecast <- function(object, is.date = NULL, ts.connect = TRUE,
   }
 
   # Filter existing values to avoid warnings
-  original.data <- dplyr::filter_(plot.data, '!is.na(Data)')
-  predict.data <- dplyr::filter_(plot.data, '!is.na(`Point_Forecast`)')
+  original.data <- dplyr::filter(plot.data, !is.na(Data))
+  predict.data <- dplyr::filter(plot.data, !is.na(`Point_Forecast`))
 
   p <- autoplot.ts(original.data, columns = 'Data', ...)
   p <- autoplot.ts(predict.data, columns = 'Point_Forecast', p = p,

--- a/R/fortify_spatial.R
+++ b/R/fortify_spatial.R
@@ -29,7 +29,7 @@ fortify.SpatialCommon <- function(model, data = NULL,
       # SpatialLines are renamed in lapply
       coords <- colnames(sp::coordinates(model))
       names(coords) <- c('long', 'lat')
-      df <- dplyr::rename_(df, .dots = coords)
+      df <- dplyr::rename(df, coords)
       }
   }
   post_fortify(df, klass = model)

--- a/R/fortify_stats.R
+++ b/R/fortify_stats.R
@@ -68,9 +68,9 @@ autoplot.acf <- function(object,
                                 conf.int.type = conf.int.type)
 
   # Prepare ymax and ymin used for geom_linerange
-  plot.data <- dplyr::mutate_(plot.data,
-                              ymax = 'ifelse(ACF > 0, ACF, 0)',
-                              ymin = 'ifelse(ACF < 0, ACF, 0)')
+  plot.data <- dplyr::mutate(plot.data,
+                              ymax = ifelse(ACF > 0, ACF, 0),
+                              ymin = ifelse(ACF < 0, ACF, 0))
 
   p <- ggplot2::ggplot(data = plot.data, mapping = ggplot2::aes_string(x = 'Lag')) +
     ggplot2::geom_linerange(mapping = ggplot2::aes_string(ymin = 'ymin', ymax = 'ymax'),

--- a/R/fortify_stats_lm.R
+++ b/R/fortify_stats_lm.R
@@ -129,15 +129,15 @@ autoplot.lm <- function(object, which = c(1:3, 5), data = NULL,
 
   if (label.n > 0L) {
     if (show[1L]) {
-      r.data <- dplyr::arrange_(plot.data, 'dplyr::desc(abs(.resid))')
+      r.data <- dplyr::arrange(plot.data, dplyr::desc(abs(.resid)))
       r.data <- utils::head(r.data, label.n)
     }
     if (".wresid" %in% colnames(plot.data)) {
-      wr.data <- dplyr::arrange_(plot.data, 'dplyr::desc(abs(.wresid))')
+      wr.data <- dplyr::arrange(plot.data, dplyr::desc(abs(.wresid)))
       wr.data <- utils::head(wr.data, label.n)
     }
     if (any(show[4L:6L])) {
-      cd.data <- dplyr::arrange_(plot.data, 'dplyr::desc(abs(.cooksd))')
+      cd.data <- dplyr::arrange(plot.data, dplyr::desc(abs(.cooksd)))
       cd.data <- utils::head(cd.data, label.n)
     }
   }

--- a/R/fortify_surv.R
+++ b/R/fortify_surv.R
@@ -306,11 +306,11 @@ fortify.aareg <- function(model, data = NULL,
     }
     d <- tidyr::gather_(d, 'variable', 'coef', cols)
     d <- d %>%
-      dplyr::group_by_('variable') %>%
-      dplyr::mutate_('se' = 'sqrt(cumsum(coef ^ 2))',
-                     'value' = 'cumsum(coef)',
-                     'upper' = 'value + se * 1.96',
-                     'lower' = 'value - se * 1.96')
+      dplyr::group_by(variable) %>%
+      dplyr::mutate(se = sqrt(cumsum(coef ^ 2)),
+                     value = cumsum(coef),
+                     upper = value + se * 1.96,
+                     lower = value - se * 1.96)
   } else {
     d <- cbind_wraps(data.frame(time = model$time[keep]),
                      apply(coefs, 2, cumsum))

--- a/R/fortify_vars.R
+++ b/R/fortify_vars.R
@@ -76,8 +76,8 @@ autoplot.varprd <- function(object, is.date = NULL, ts.connect = TRUE,
                                 ts.connect = ts.connect, melt = TRUE)
 
   # Filter existing values to avoid warnings
-  original.data <- dplyr::filter_(plot.data, '!is.na(Data)')
-  predict.data <- dplyr::filter_(plot.data, '!is.na(fcst)')
+  original.data <- dplyr::filter(plot.data, !is.na(Data))
+  predict.data <- dplyr::filter(plot.data, !is.na(fcst))
 
   p <- autoplot.ts(original.data, columns = 'Data', ...)
 

--- a/R/plotlib.R
+++ b/R/plotlib.R
@@ -610,7 +610,8 @@ ggbiplot <- function(plot.data, loadings.data = NULL,
         hulls <- plot.data[grDevices::chull(plot.data[, 1L:2L]), ]
       } else {
         hulls <- plot.data %>%
-          dplyr::group_by_(frame.colour) %>%
+          dplyr::group_by(.data[[frame.colour]]) %>%
+          dplyr::select(1:2) %>%
           dplyr::do(.[grDevices::chull(.[, 1L:2L]), ])
       }
       mapping <- aes_string(colour = frame.colour, fill = frame.colour)

--- a/R/tslib.R
+++ b/R/tslib.R
@@ -356,8 +356,8 @@ ggfreqplot <- function(data, freq = NULL,
   freqd <- data.frame(Frequency = rep(freqs, length.out = length(data)))
   d <- cbind(d, freqd)
 
-  summarised <- dplyr::group_by_(d, 'Frequency') %>%
-    dplyr::summarise_(m = 'mean(Data)', s = 'sd(Data)')
+  summarised <- dplyr::group_by(d, Frequency) %>%
+    dplyr::summarise(m = mean(Data), s = sd(Data))
 
   p <- (1 - conf.int.value) / 2
   summarised$lower <- stats::qnorm(p, mean = summarised$m, sd = summarised$s)

--- a/R/util.R
+++ b/R/util.R
@@ -45,7 +45,7 @@ cbind_wraps <- function(df1, df2) {
   # prioritize df1 columns
   dots <- names(df2)[! colnames(df2) %in% colnames(df1)]
   if (length(dots) != length(colnames(df2))) {
-    df2 <- dplyr::select(df2, .dots = dots)
+    df2 <- dplyr::select(df2, all_of(dots))
   }
   return(cbind(df1, df2))
 }

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -29,7 +29,7 @@ test_that('post_fortify', {
   res <- ggfortify:::post_fortify(df)
   expect_equal(res, df)
 
-  tbl <- dplyr::data_frame(x = c(1, 2, 3), y = c(4, 5, 6))
+  tbl <- dplyr::tibble(x = c(1, 2, 3), y = c(4, 5, 6))
   expect_true(is(tbl, 'tbl_df'))
   res <- ggfortify:::post_fortify(tbl)
   expect_equal(res, df)

--- a/tests/testthat/test_lint.R
+++ b/tests/testthat/test_lint.R
@@ -6,7 +6,7 @@ test_that("Code Lint", {
   skip_if_not_installed("lintr")
 
   my_linters <- list(
-    absolute_paths_linter=lintr::absolute_paths_linter,
+    absolute_paths_linter=lintr::absolute_path_linter,
     assignment_linter=lintr::assignment_linter,
     closed_curly_linter=lintr::closed_curly_linter,
     commas_linter=lintr::commas_linter,


### PR DESCRIPTION
I've updated many of the files.  The other pull request you received had a problem where 

    select_cols <- c('Petal.Length','Sepal.Length')
    iris %>%
    #  select(select_cols)   #  Generates a warning...
        select(all_of(select_cols))  # is recommended

the first version generates a warning and tells us to use the all_of() command instead. 

Also, there was a do() function call plotlib.R that was throwing a warning about using progress bars, but I can't seem to recreate it now, so I decided not to change that piece. The dplyr::do() command is superseded and not recommended and I thought about swapping it out with 

    dplyr::summarize(across(grDevices::chull()))

but decided against it.

When I run the package tests, there are still some unresolved problems, but I think they were there when I first forked the package.  So double checking the tests would be highly recommended.