### PR TITLE
Support survfit objects with multiple stratification variables. Fixes #214

### DIFF
--- a/R/fortify_surv.R
+++ b/R/fortify_surv.R
@@ -46,7 +46,7 @@ fortify.survfit <- function(model, data = NULL, surv.connect = FALSE,
     }
 
     if ('strata' %in% names(model)) {
-      groupIDs <- gsub(".*=", '', names(model$strata))
+      groupIDs <- gsub("[^,]*=", '', names(model$strata))
       groupIDs <- factor(rep(groupIDs, model$strata), levels = groupIDs)
       if ('states' %in% names(model)) {
         groupIDs <- rep(groupIDs, length(model$states))

--- a/tests/testthat/test-surv.R
+++ b/tests/testthat/test-surv.R
@@ -249,3 +249,15 @@ test_that('autoplot.aareg works for lung', {
   expect_equal(length(ld2$fill), 6)
   expect_equal(ld2$alpha, rep(0.3, 6))
 })
+
+test_that('fortify.survfit regular expression for renaming strata works with multiple stratification variables', {
+  skip_if_not_installed("survival")
+  library(survival)
+  d.survfit <- survival::survfit(Surv(time, status) ~ sex + ph.ecog, data = lung)
+  fortified <- ggplot2::fortify(d.survfit)
+  expect_equal(is.data.frame(fortified), TRUE)
+  expected_names <- c('time', 'n.risk', 'n.event', 'n.censor', 'surv',
+                      'std.err', 'upper', 'lower', 'strata')
+  expect_equal(names(fortified), expected_names)
+  expect_equal(length(fortified$strata), 8)
+})


### PR DESCRIPTION
In fortify_surv.R, changed the regular expression on line 49 to be "[^,]*=" instead of ".*=". This is in response to Issue #214, and the change is meant to allow autoplot to work on survfit objects with multiple stratification variables.

[testResults.txt](https://github.com/sinhrks/ggfortify/files/6942723/testResults.txt)
