### PR TITLE
Fix frame for clusters

### DIFF
--- a/R/plotlib.R
+++ b/R/plotlib.R
@@ -626,7 +626,6 @@ ggbiplot <- function(plot.data, loadings.data = NULL,
       } else {
         hulls <- plot.data %>%
           dplyr::group_by(.data[[frame.colour]]) %>%
-          dplyr::select(1:2) %>%
           dplyr::do(.[grDevices::chull(.[, 1L:2L]), ])
       }
       mapping <- aes_string(colour = frame.colour, fill = frame.colour)


### PR DESCRIPTION
Some of the recent changes in ggfortify introduced a bug when plotting cluster results with frame on. For example, 

```
autoplot(stats::kmeans(iris[-5], 3), data = iris, frame=TRUE)
```
produced this plot:
![cluster_bug](https://user-images.githubusercontent.com/31703384/137597275-db703311-1e38-484a-a00d-13d255efae21.png)

when it should have been this
![cluster_correct](https://user-images.githubusercontent.com/31703384/137597291-7657a0fa-a891-4ab9-8410-56f4c69df537.png)
:

I believe it was caused by one line in `ggbiplot` that I removed in this PR.

Please let me know if I missed anything!