### PR TITLE
fix: "colour" vs "color" when calling autoplot on a PCA 

### DIFF
--- a/R/plotlib.R
+++ b/R/plotlib.R
@@ -547,6 +547,30 @@ ggbiplot <- function(plot.data, loadings.data = NULL,
                      ...) {
 #  print(label.position)
 
+  arguments <- list(...)
+
+  if ("color" %in% names(arguments)) {
+    if (missing(colour)) {
+      colour <- arguments[["color"]]
+    } else {
+      warning("both 'colour=' and 'color=' found, ignoring 'color='")
+    }
+  }
+  if ("loadings.color" %in% names(arguments)) {
+    if (missing(loadings.colour)) {
+      loadings.colour <- arguments[["loadings.color"]]
+    } else {
+      warning("both 'loadings.colour=' and 'loadings.color=' found, ignoring 'loadings.color='")
+    }
+  }
+  if ("loadings.label.color" %in% names(arguments)) {
+    if (missing(loadings.label.colour)) {
+      loadings.label.colour <- arguments[["loadings.label.color"]]
+    } else {
+      warning("both 'loadings.label.colour=' and 'loadings.label.color=' found, ignoring 'loadings.label.color='")
+    }
+  }
+
   plot.columns <- colnames(plot.data)
   mapping <- ggplot2::aes_string(x = plot.columns[1L], y = plot.columns[2L])
 


### PR DESCRIPTION
This isn't the cleanest but fixes #224. Ideally I would've preferred to do it [like ggplot does it](https://github.com/tidyverse/ggplot2/blob/759c63c2fd9e00ba3322c1b74b227f63c98d2e06/R/aes.r#L159), but couldn't get it to work.