### PR TITLE
Use exported value of ggplot2::GeomRibbon

### DIFF
--- a/R/geom.R
+++ b/R/geom.R
@@ -22,7 +22,7 @@ GeomConfint <- ggplot2::ggproto('GeomConfint', ggplot2::GeomRibbon,
     if (na.rm) data <- data[stats::complete.cases(self$required_aes), ]
     data <- data[order(data$group, data$x), ]
     data <- self$stairstep_confint(data)
-    ggplot2:::GeomRibbon$draw_group(data, panel_scales, coord, na.rm = FALSE)
+    ggplot2::GeomRibbon$draw_group(data, panel_scales, coord, na.rm = FALSE)
   },
   stairstep_confint = function (data) {
     data <- as.data.frame(data)[order(data$x), ]


### PR DESCRIPTION
https://github.com/tidyverse/ggplot2/blob/6e8ac77790c90ef6f8cedf91f932bb77c7a4b19e/NAMESPACE#L180

As reported by `tools:::.check_packages_used()`.