### PR TITLE
Prepare release 0.4.20

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ggfortify
 Type: Package
 Title: Data Visualization Tools for Statistical Analysis Results
-Version: 0.4.19
-Date: 2025-07-26
+Version: 0.4.20
+Date: 2026-07-26
 Authors@R: c(
   person("Masaaki", "Horikoshi", role = c("aut"),
          email = "sinhrks@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## ggfortify 0.4.20
+
+* Replaced deprecated `ggplot2::aes_string()` calls with `ggplot2::aes()` and the `.data` pronoun.
+* Switched from the internal `ggplot2:::GeomRibbon` object to the exported `ggplot2::GeomRibbon` object.
+
 ## ggfortify 0.4.19
 
 * Fixed failed tests in test-stat and test-ts with `ggplot2` 4.0.0.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -11,4 +11,5 @@
 
 Notable changes are:
 
-* Fixed failed tests in test-stat and test-ts with `ggplot2` 4.0.0.
+* Replaced deprecated `ggplot2::aes_string()` calls with `ggplot2::aes()` and the `.data` pronoun.
+* Switched from the internal `ggplot2:::GeomRibbon` object to the exported `ggplot2::GeomRibbon` object.


### PR DESCRIPTION
This PR prepares a new ggfortify 0.4.20 release based on the updates already contributed and merged by the project’s authors since 0.4.19, which fixes #236. 

It only updates the release-related files:

- Bumps the package version to 0.4.20.
- Updates the release date.
- Documents the existing ggplot2 compatibility improvements in NEWS.md.
- Updates cran-comments.md accordingly.

No functional code changes are introduced by this PR.

Validation performed with R 4.5.3:

- Package build succeeded.
- R CMD check passed.
- Tests and examples passed.