### PR TITLE
Fix surv.connect for unstratified survival fits

### DIFF
--- a/R/fortify_surv.R
+++ b/R/fortify_surv.R
@@ -18,6 +18,10 @@
 #' @export
 fortify.survfit <- function(model, data = NULL, surv.connect = FALSE,
                             fun = NULL, ...) {
+  if (surv.connect) {
+    model <- survival::survfit0(model)
+  }
+
   if (inherits(model, 'survfitms')) {
     d <- data.frame(time = model$time,
                     n.risk = c(model$n.risk),
@@ -61,28 +65,6 @@ fortify.survfit <- function(model, data = NULL, surv.connect = FALSE,
     }
   } else {
     stop(paste0('Unsupported class for fortify.survfit: ', class(model)))
-  }
-
-  # connect to the origin for plotting
-  if (surv.connect) {
-    if ('strata' %in% colnames(d)) {
-      base <- d[d$time == ave(d$time, d$strata, FUN = min), ]
-    }
-    if ('event' %in% colnames(d)) {
-      base <- d[d$time == ave(d$time, d$event, FUN = min), ]
-    }
-    # cumhaz is for survfit.cox cases
-    base[intersect(c('time', 'n.event', 'n.censor', 'std.err', 'cumhaz'), colnames(base))] <- 0
-    if ('pstate' %in% colnames(d)) {
-      base[c('pstate', 'upper', 'lower')] <- 0
-    } else {
-      base[c('surv', 'upper', 'lower')] <- 1.0
-    }
-    if ('event' %in% colnames(d)) {
-     base[base$event == 'any', c('pstate', 'upper', 'lower')] <- 1.0
-    }
-    rownames(base) <- NULL
-    d <- rbind(base, d)
   }
 
   if (!is.null(fun)) {

--- a/tests/testthat/test-surv.R
+++ b/tests/testthat/test-surv.R
@@ -261,20 +261,34 @@ test_that('fortify.survfit regular expression for renaming strata works with mul
   expect_equal(names(fortified), expected_names)
 })
 
-test_that('n.risk at time == 0 is correct in fortify.survfit(*, surv.connect = TRUE) (#229)', {
+test_that('surv.connect uses the correct starting points (#229)', {
   skip_if_not_installed("survival")
   library(survival)
 
   fit <- survfit(Surv(time, status) ~ x, data = aml)
-  fit_surv <- summary(fit)
-  fit_surv <- fit_surv$n.risk[fit_surv$time == ave(fit_surv$time, fit_surv$strata, FUN = min)]
   fit_gg <- fortify.survfit(fit, surv.connect = TRUE)
-  fit_gg <- fit_gg[fit_gg$time == 0, "n.risk"]
-  expect_equal(fit_surv, fit_gg)
-  
-  fitMS <- survfit(Surv(start, stop, event) ~ 1, id = id, data = mgus1)
-  fitMS_surv <- unname(fitMS$n.risk[1, ])
-  fitMS_gg <- fortify.survfit(fitMS, surv.connect = TRUE)
-  fitMS_gg <- fitMS_gg[fitMS_gg$time == 0, "n.risk"]
-  expect_equal(fitMS_surv, fitMS_gg)
+  fit_gg <- fit_gg[fit_gg$time == 0, ]
+  expect_equal(fit_gg$n.risk, c(11, 12))
+
+  fit_ms <- survfit(Surv(start, stop, event) ~ sex, id = id, data = mgus1)
+  fit_ms_gg <- fortify.survfit(fit_ms, surv.connect = TRUE)
+  fit_ms_gg <- fit_ms_gg[fit_ms_gg$time == 0, ]
+  expect_equal(nrow(fit_ms_gg), 6)
+  expect_equal(fit_ms_gg$pstate, c(1, 1, 0, 0, 0, 0))
+  expect_equal(fit_ms_gg$n.risk, c(104, 137, 0, 0, 0, 0))
+
+  zero_event <- data.frame(time = c(0, 1, 2, 3),
+                           status = c(1, 0, 1, 0))
+  fit_zero <- survfit(Surv(time, status) ~ 1, data = zero_event)
+  fit_zero_gg <- fortify.survfit(fit_zero, surv.connect = TRUE)
+  expect_equal(sum(fit_zero_gg$time == 0), 1)
+  expect_equal(fit_zero_gg$surv[fit_zero_gg$time == 0], 0.75)
+
+  delayed <- data.frame(start = c(2, 3, 4, 4),
+                        stop = c(5, 6, 7, 8),
+                        status = c(1, 0, 1, 0))
+  fit_delayed <- survfit(Surv(start, stop, status) ~ 1,
+                         data = delayed, start.time = 2)
+  fit_delayed_gg <- fortify.survfit(fit_delayed, surv.connect = TRUE)
+  expect_equal(min(fit_delayed_gg$time), 2)
 })


### PR DESCRIPTION
(Created with the assistance of Codex, GPT-5.6.)
Closes #229.

## Problem

`fortify.survfit(..., surv.connect = TRUE)` manually constructed starting rows from the fortified data.

This caused several problems:

- Unstratified fits have neither a `strata` nor an `event` column, so `base` was never created, resulting in `object 'base' not found` (#234).
- Stratified multistate fits were grouped by either `strata` or `event`, rather than both, causing missing starting rows.
- Every curve was forced to start at time zero, ignoring the `t0` or `start.time` stored in the `survfit` object.
- An event occurring at time zero produced an artificial duplicate pre-event row.
- Multistate starting probabilities could be initialized incorrectly.

## Solution

Use `survival::survfit0()` when `surv.connect = TRUE` before converting the model to a data frame.

`survfit0()` is the dedicated utility used by the `survival` package to prepare survival curves for plotting. It determines the appropriate starting time and keeps the survival, risk, event, censoring, multistate probability, confidence interval, and standard-error components
aligned.

This also removes the package's manual starting-row construction.

Behavior with `surv.connect = FALSE` is unchanged.

## Tests

The regression tests now cover:

- Unstratified survival fits.
- Correct `n.risk` values for stratified fits.
- Stratified multistate starting rows and probabilities.
- Events occurring exactly at time zero.
- Counting-process fits with a nonzero `start.time`.

The survival tests pass with:

- R 4.1.0 / survival 3.2.11 / ggplot2 3.3.3
- R 4.2.1 / survival 3.3.1 / ggplot2 3.3.6
- R 4.4.2 / survival 3.7.0
- R 4.5.1 / survival 3.8.3

The full repository test suite also passes.