### PR TITLE
Fix `fortify.survfit()` with `surv.connect = TRUE` for fits without strata

### DIFF
--- a/R/fortify_surv.R
+++ b/R/fortify_surv.R
@@ -65,6 +65,7 @@ fortify.survfit <- function(model, data = NULL, surv.connect = FALSE,
 
   # connect to the origin for plotting
   if (surv.connect) {
+    base <- d[d$time == min(d$time), , drop = FALSE]
     if ('strata' %in% colnames(d)) {
       base <- d[d$time == ave(d$time, d$strata, FUN = min), ]
     }

--- a/tests/testthat/test-surv.R
+++ b/tests/testthat/test-surv.R
@@ -62,18 +62,18 @@ test_that('fortify.survfit works for lung', {
   p <- ggplot2::autoplot(d.survfit)
   expect_true(is(p, 'ggplot'))
 
-  # fortified <- ggplot2::fortify(d.survfit, surv.connect = TRUE)
-  # expect_equal(is.data.frame(fortified), TRUE)
-  # expected_names <- c('time', 'n.risk', 'n.event', 'n.censor', 'surv',
-  #                     'std.err', 'upper', 'lower')
-  # expect_equal(names(fortified), expected_names)
-  # expect_equal(dim(fortified), c(187, 8))
-  # expected <- data.frame(time = 0, n.risk = 228, n.event = 0, n.censor = 0,
-  #                        surv = 1, std.err = 0, upper = 1, lower = 1)
-  # expect_equal(fortified[1, ], expected)
-  # 
-  # p <- ggplot2::autoplot(d.survfit)
-  # expect_true(is(p, 'ggplot'))
+  fortified <- ggplot2::fortify(d.survfit, surv.connect = TRUE)
+  expect_equal(is.data.frame(fortified), TRUE)
+  expected_names <- c('time', 'n.risk', 'n.event', 'n.censor', 'surv',
+                      'std.err', 'upper', 'lower')
+  expect_equal(names(fortified), expected_names)
+  expect_equal(dim(fortified), c(187, 8))
+  expected <- data.frame(time = 0, n.risk = 228, n.event = 0, n.censor = 0,
+                         surv = 1, std.err = 0, upper = 1, lower = 1)
+  expect_equal(fortified[1, ], expected)
+
+  p <- ggplot2::autoplot(d.survfit, surv.connect = TRUE)
+  expect_true(is(p, 'ggplot'))
 })
 
 test_that('autoplot retains order of alphabetically unordered factor levels', {


### PR DESCRIPTION
(Created with the assistance of Codex, GPT-5.6. Manually reviewed and tested.)
Closes #234.

## Problem

`fortify.survfit(..., surv.connect = TRUE)` only initialized `base` when the fortified data contained a `strata` or `event` column.

For an unstratified fit such as:

```r
survfit(Surv(time, status) ~ 1, data = lung)
```
neither condition was satisfied. The subsequent code therefore attempted to modify an undefined base object:
```
Error: object 'base' not found
```
## Fix

Initialize base from the earliest observation before applying the existing grouped special cases:
```r
base <- d[d$time == min(d$time), , drop = FALSE]
```
This provides a starting row for unstratified fits while preserving the existing handling for stratified and multistate fits.

## Tests

Restores the previously disabled unstratified `lung` regression test and verifies:

- `fortify(..., surv.connect = TRUE)`
- `autoplot(..., surv.connect = TRUE)`

## Test Example
```r
# Helps on headless RStudio Server / Open OnDemand
if (capabilities("cairo")) {
  options(bitmapType = "cairo")
}

library(survival)
library(ggplot2)
library(ggfortify)

fit <- survfit(
  Surv(time, status) ~ 1,
  data = lung
)

# This previously failed with:
# Error: object 'base' not found
fortified <- fortify(
  fit,
  surv.connect = TRUE
)

print(head(fortified))

# Verify the added starting row
stopifnot(
  is.data.frame(fortified),
  nrow(fortified) == 187,
  fortified$time[1] == 0,
  fortified$n.risk[1] == 228,
  fortified$n.event[1] == 0,
  fortified$n.censor[1] == 0,
  fortified$surv[1] == 1,
  fortified$std.err[1] == 0,
  fortified$upper[1] == 1,
  fortified$lower[1] == 1
)

# Verify autoplot also works
p <- autoplot(
  fit,
  surv.connect = TRUE
)

stopifnot(inherits(p, "ggplot"))
print(p)

message("PR #244 regression test passed")
```
<img width="1857" height="839" alt="image" src="https://github.com/user-attachments/assets/9113ff9b-a81c-4af5-821d-68ca0297f7b1" />
