### PR TITLE
Add loading cutoff option for PCA biplots

### DIFF
--- a/R/fortify_stats.R
+++ b/R/fortify_stats.R
@@ -238,6 +238,8 @@ fortify.lfda <- function(model, data = NULL, ...) {
 #' autoplot(stats::prcomp(iris[-5]), data = iris)
 #' autoplot(stats::prcomp(iris[-5]), data = iris, colour = 'Species')
 #' autoplot(stats::prcomp(iris[-5]), label = TRUE, loadings = TRUE, loadings.label = TRUE)
+#' autoplot(stats::prcomp(iris[-5]), loadings = TRUE, loadings.label = TRUE,
+#'          loadings.cutoff = 0.7)
 #' autoplot(stats::prcomp(iris[-5]), frame = TRUE)
 #' autoplot(stats::prcomp(iris[-5]), data = iris, frame = TRUE,
 #'          frame.colour = 'Species')

--- a/R/plotlib.R
+++ b/R/plotlib.R
@@ -483,6 +483,9 @@ autoplot.ggmultiplot <- function(object, ...) {
 #' @param label Logical value whether to display data labels
 #' @inheritParams plot_label
 #' @param loadings Logical value whether to display loadings arrows
+#' @param loadings.cutoff Minimum Euclidean length of the unscaled loading
+#'   vectors in the selected two-dimensional component space. Disabled when
+#'   \code{NULL}.
 #' @param loadings.arrow An arrow definition
 #' @param loadings.colour Point colour for data
 #' @param loadings.linewidth Segment linewidth for loadings
@@ -526,6 +529,7 @@ ggbiplot <- function(plot.data, loadings.data = NULL,
                      label.repel = FALSE,
                      label.position = "identity",
                      loadings = FALSE,
+                     loadings.cutoff = NULL,
                      loadings.arrow = grid::arrow(length = grid::unit(8, 'points')),
                      loadings.colour = '#FF0000',
                      loadings.linewidth = 0.5,
@@ -549,6 +553,12 @@ ggbiplot <- function(plot.data, loadings.data = NULL,
                      main = NULL, xlab = NULL, ylab = NULL, asp = NULL,
                      ...) {
 #  print(label.position)
+
+  if (!is.null(loadings.cutoff) &&
+      (!is.numeric(loadings.cutoff) || length(loadings.cutoff) != 1L ||
+       !is.finite(loadings.cutoff) || loadings.cutoff < 0)) {
+    stop("'loadings.cutoff' must be NULL or a single finite, non-negative number")
+  }
 
   arguments <- list(...)
 
@@ -606,6 +616,15 @@ ggbiplot <- function(plot.data, loadings.data = NULL,
   if (loadings.label && !loadings) {
     # If loadings.label is TRUE, draw loadings
     loadings <- TRUE
+  }
+  if (!is.null(loadings.data) && !is.null(loadings.cutoff)) {
+    loading.length <- sqrt(rowSums(loadings.data[, 1L:2L, drop = FALSE]^2))
+    loadings.data <- loadings.data[
+      loading.length >= loadings.cutoff, , drop = FALSE
+    ]
+    if (nrow(loadings.data) == 0L) {
+      loadings.data <- NULL
+    }
   }
   if (loadings && !is.null(loadings.data)) {
 

--- a/man/autoplot.pca_common.Rd
+++ b/man/autoplot.pca_common.Rd
@@ -40,6 +40,8 @@ autoplot(stats::prcomp(iris[-5]))
 autoplot(stats::prcomp(iris[-5]), data = iris)
 autoplot(stats::prcomp(iris[-5]), data = iris, colour = 'Species')
 autoplot(stats::prcomp(iris[-5]), label = TRUE, loadings = TRUE, loadings.label = TRUE)
+autoplot(stats::prcomp(iris[-5]), loadings = TRUE, loadings.label = TRUE,
+         loadings.cutoff = 0.7)
 autoplot(stats::prcomp(iris[-5]), frame = TRUE)
 autoplot(stats::prcomp(iris[-5]), data = iris, frame = TRUE,
          frame.colour = 'Species')

--- a/man/ggbiplot.Rd
+++ b/man/ggbiplot.Rd
@@ -27,6 +27,7 @@ ggbiplot(
   label.repel = FALSE,
   label.position = "identity",
   loadings = FALSE,
+  loadings.cutoff = NULL,
   loadings.arrow = grid::arrow(length = grid::unit(8, "points")),
   loadings.colour = "#FF0000",
   loadings.linewidth = 0.5,
@@ -102,6 +103,10 @@ ggbiplot(
 \item{label.position}{Character or a position function}
 
 \item{loadings}{Logical value whether to display loadings arrows}
+
+\item{loadings.cutoff}{Minimum Euclidean length of the unscaled loading
+vectors in the selected two-dimensional component space. Disabled when
+\code{NULL}.}
 
 \item{loadings.arrow}{An arrow definition}
 

--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -541,6 +541,36 @@ test_that('autoplot.prcomp works for iris with scale (default)', {
   expect_equal(ld$alpha, rep(0.2, 6))
 })
 
+test_that('autoplot.pca_common filters loadings by vector length (#212)', {
+  obj <- stats::prcomp(iris[-5])
+
+  p <- ggplot2::autoplot(
+    obj, x = 2, y = 3, loadings = TRUE, loadings.label = TRUE,
+    loadings.cutoff = 0.7
+  )
+  expect_equal(length(p$layers), 3)
+  expect_equal(nrow(ggplot2:::layer_data(p, 2)), 2)
+  expect_setequal(
+    ggplot2:::layer_data(p, 3)$label,
+    c('Sepal.Length', 'Sepal.Width')
+  )
+
+  p <- ggplot2::autoplot(
+    obj, loadings = TRUE, loadings.label = TRUE,
+    loadings.cutoff = 2
+  )
+  expect_equal(length(p$layers), 1)
+
+  invalid <- list(-1, Inf, NA_real_, c(0.1, 0.2), '0.1')
+  for (cutoff in invalid) {
+    expect_error(
+      ggplot2::autoplot(obj, loadings.cutoff = cutoff),
+      "'loadings.cutoff' must be NULL or a single finite, non-negative number",
+      fixed = TRUE
+    )
+  }
+})
+
 test_that('autoplot.prcomp works for iris without scale', {
 
   # fails on CRAN i386 because components are inversed.


### PR DESCRIPTION
(Created with the assistance of Codex, GPT-5.6. Manually reviewed and tested.)
Closes #212.

## Summary

This PR adds a `loadings.cutoff` argument to `ggbiplot()` for filtering weak PCA loading vectors.

The cutoff is applied to the Euclidean length of each unscaled loading vector in the selected two-dimensional component space. Loading arrows and labels below the cutoff are omitted.

For example:

```r
autoplot(
  prcomp(iris[, 1:4], scale. = TRUE),
  data = iris,
  colour = "Species",
  x = 2,
  y = 3,
  loadings = TRUE,
  loadings.label = TRUE,
  loadings.cutoff = 0.7
)
```
The default is NULL, so existing behavior remains unchanged. The implementation also handles cases where every loading is filtered and validates invalid cutoff values.

## Testing
```r
if (capabilities("cairo")) {
  options(bitmapType = "cairo")
}

library(ggplot2)
library(ggfortify)

pca <- prcomp(iris[, 1:4], scale. = TRUE)

# Examine loading lengths for the selected components
selected_loadings <- pca$rotation[, c(2, 3), drop = FALSE]

loading_table <- data.frame(
  variable = rownames(selected_loadings),
  length = sqrt(rowSums(selected_loadings^2))
)

print(loading_table)
```
### Plot all loading arrows
```r
p_all <- autoplot(
  pca,
  data = iris,
  colour = "Species",
  x = 2,
  y = 3,
  loadings = TRUE,
  loadings.label = TRUE
)

print(p_all)
```
<img width="837" height="434" alt="image" src="https://github.com/user-attachments/assets/c8fb592a-cdc7-411a-8253-8d32acd246be" />

### Only loading vectors with length >= 0.7
```r
p_filtered <- autoplot(
  pca,
  data = iris,
  colour = "Species",
  x = 2,
  y = 3,
  loadings = TRUE,
  loadings.label = TRUE,
  loadings.cutoff = 0.7
)

print(p_filtered)
```
<img width="837" height="434" alt="image" src="https://github.com/user-attachments/assets/35db8e7d-f110-4595-b2d2-7d25b240c368" />

### Remove all loading arrows and labels
```r
p_none <- autoplot(
  pca,
  data = iris,
  colour = "Species",
  x = 2,
  y = 3,
  loadings = TRUE,
  loadings.label = TRUE,
  loadings.cutoff = 2
)

print(p_none)
```
<img width="837" height="434" alt="image" src="https://github.com/user-attachments/assets/b8038c17-79d5-41a2-b0a1-a715d66856a5" />
