### PR TITLE
Fix ggdistribution axis label overrides

### DIFF
--- a/R/fortify_stats_density.R
+++ b/R/fortify_stats_density.R
@@ -45,9 +45,7 @@ autoplot.density <- function (object, p = NULL,
     if (is.null(ylab)) {
       ylab = ''
     }
-    p <- ggplot2::ggplot(mapping = mapping) +
-      ggplot2::scale_x_continuous(name = xlab) +
-      ggplot2::scale_y_continuous(name = ylab)
+    p <- ggplot2::ggplot(mapping = mapping)
   }
   if (!is.null(fill)) {
 

--- a/tests/testthat/test-stats-density.R
+++ b/tests/testthat/test-stats-density.R
@@ -23,3 +23,17 @@ test_that('ggdistribution', {
   p <- ggdistribution(pchisq, 0:20, p = p, df = 9, fill = 'red')
   expect_true(is(p, 'ggplot'))
 })
+
+test_that('ggdistribution axis labels can be customized', {
+  p <- ggdistribution(dnorm, seq(-3, 3, 0.1),
+                      mean = 0, sd = 1,
+                      xlab = 'direct x', ylab = 'direct y')
+  expect_equal(p$labels$x, 'direct x')
+  expect_equal(p$labels$y, 'direct y')
+
+  p <- p + ggplot2::labs(x = 'later x', y = 'later y')
+  expect_equal(p$labels$x, 'later x')
+  expect_equal(p$labels$y, 'later y')
+  expect_null(p$scales$get_scales('x'))
+  expect_null(p$scales$get_scales('y'))
+})


### PR DESCRIPTION
Created with the assistance of Codex, GPT-5.6. Manually reviewed and tested.
## Summary

Fixes #218.

`ggdistribution()` previously assigned axis titles directly to its continuous scales. Because explicit scale names take precedence over plot labels, subsequent calls such as:

```r
ggdistribution(...) +
  ggplot2::labs(x = "x label", y = "y label")
```
could not override the original or default axis titles.

This change removes the redundant explicit scales and lets `post_autoplot()` manage axis labels through ggplot2’s normal label mechanism.

Both forms now work:
```r
ggdistribution(..., xlab = "direct x", ylab = "direct y")
```
```r
ggdistribution(...) +
  ggplot2::labs(x = "later x", y = "later y")
```

## Test
```r
library(ggplot2)

p <- ggdistribution(
  dnorm,
  seq(-3, 3, 0.1),
  mean = 0,
  sd = 1,
  xlab = "Original x",
  ylab = "Original y"
) +
  labs(
    title = "ggdistribution Cairo test",
    x = "Overridden x",
    y = "Overridden y"
  )

print(p)
```
<img width="837" height="507" alt="image" src="https://github.com/user-attachments/assets/3b4d5b7a-2154-4318-b0a2-6ee7c86c21de" />
