### PR TITLE
Render discrete CDFs with step geometry in ggdistribution

### DIFF
--- a/R/fortify_stats_density.R
+++ b/R/fortify_stats_density.R
@@ -47,6 +47,10 @@ autoplot.density <- function (object, p = NULL,
     }
     p <- ggplot2::ggplot(mapping = mapping)
   }
+  is.discrete <- isTRUE(attr(object, 'ggfortify.discrete_cdf'))
+  geomfunc <- if (is.discrete) geom_step else geom_line
+  ribbonfunc <- if (is.discrete) geom_confint else geom_ribbon
+
   if (!is.null(fill)) {
 
     if (is.null(alpha)) {
@@ -54,16 +58,25 @@ autoplot.density <- function (object, p = NULL,
       alpha <- 0.3
     }
 
-    p <- p + geom_factory(geom_ribbon, object, colour = colour,
+    p <- p + geom_factory(ribbonfunc, object, colour = colour,
                           linetype = linetype, fill = fill, alpha = alpha)
   } else {
     # not to draw bottom line
-    p <- p + geom_factory(geom_line, object, colour = colour,
+    p <- p + geom_factory(geomfunc, object, colour = colour,
                           linetype = linetype, alpha = alpha)
   }
   p <- post_autoplot(p = p, xlim = xlim, ylim = ylim, log = log,
                      main = main, xlab = xlab, ylab = ylab, asp = asp)
   p
+}
+
+is_discrete_cdf <- function(func) {
+  discrete_cdfs <- list(
+    stats::pbinom, stats::pgeom, stats::phyper, stats::pnbinom,
+    stats::ppois, stats::psignrank, stats::pwilcox
+  )
+  inherits(func, 'stepfun') ||
+    any(vapply(discrete_cdfs, identical, logical(1L), y = func))
 }
 
 #' Plot distribution
@@ -99,6 +112,7 @@ ggdistribution <- function (func, x, p = NULL,
                             asp = NULL, ...)  {
   data <- data.frame(x = x, y = func(x, ...),
                      ymin = rep(0, length(x)))
+  attr(data, 'ggfortify.discrete_cdf') <- is_discrete_cdf(func)
   p <- autoplot.density(data, p = p, colour = colour, linetype = linetype,
                         fill = fill, alpha = alpha, 
                         xlim = xlim, ylim = ylim, log = log,

--- a/tests/testthat/test-stats-density.R
+++ b/tests/testthat/test-stats-density.R
@@ -15,7 +15,14 @@ test_that('fortify.density works for rnorm', {
 
 test_that('ggdistribution', {
   p <- ggdistribution(dnorm, seq(-3, 3, 0.1), mean = 0, sd = 1)
+  expect_true(is(p$layers[[1]]$geom, 'GeomLine'))
+
   p <- ggdistribution(ppois, seq(0, 30), lambda = 20)
+  expect_true(is(p$layers[[1]]$geom, 'GeomStep'))
+
+  p <- ggdistribution(ppois, seq(0, 30), lambda = 20,
+                      fill = 'blue')
+  expect_true(is(p$layers[[1]]$geom, 'GeomConfint'))
 
   # repeast
   p <- ggdistribution(pchisq, 0:20, df = 7, fill = 'blue')
@@ -36,4 +43,14 @@ test_that('ggdistribution axis labels can be customized', {
   expect_equal(p$labels$y, 'later y')
   expect_null(p$scales$get_scales('x'))
   expect_null(p$scales$get_scales('y'))
+})
+
+test_that('standard discrete CDFs are detected', {
+  discrete_cdfs <- list(pbinom, pgeom, phyper, pnbinom,
+                        ppois, psignrank, pwilcox)
+  detected <- vapply(discrete_cdfs, ggfortify:::is_discrete_cdf, logical(1L))
+  expect_true(all(detected))
+  expect_true(ggfortify:::is_discrete_cdf(ecdf(0:3)))
+  expect_false(ggfortify:::is_discrete_cdf(pnorm))
+  expect_false('geom' %in% names(formals(ggdistribution)))
 })


### PR DESCRIPTION
Created with the assistance of Codex, GPT-5.6. Manually reviewed and tested.
## Summary

Fixes #166.

`ggdistribution()` previously rendered every distribution using a continuous line. This made discrete CDFs such as:

```r
ggdistribution(ppois, 0:30, lambda = 20)
```
appear continuous.

This change:

- detects standard discrete CDF functions, including ppois
- renders discrete CDFs with step geometry
- continues to render continuous distributions with line geometry
- uses stepped confidence-area geometry when fill is specified

The detected discrete CDFs are:

- pbinom
- pgeom
- phyper
- pnbinom
- ppois
- psignrank
- pwilcox
- functions inheriting from stepfun, including ecdf results

## Test
```r
p <- ggdistribution(
  ppois,
  0:30,
  lambda = 20
)

print(p)
```
<img width="837" height="507" alt="image" src="https://github.com/user-attachments/assets/b9b1c613-cc54-4aa5-88ac-71e03a8d6a2a" />

