### PR TITLE
Support fixed and per-group colours for survival curves

### DIFF
--- a/R/fortify_surv.R
+++ b/R/fortify_surv.R
@@ -122,8 +122,9 @@ fortify.survfit <- function(model, data = NULL, surv.connect = FALSE,
 #' @param fun an arbitrary function defining a transformation of the survival curve
 #' @param surv.geom geometric string for survival curve. 'step', 'line' or 'point'
 #' @param surv.colour Line colour for the survival curve. A plot-data column
-#'   name maps colour and creates a legend; a colour value sets a fixed colour
-#'   and does not create a legend.
+#'   name maps colour and creates a legend; a single colour value sets a fixed
+#'   colour; and a vector supplies a manual palette for the automatically
+#'   mapped grouping variable.
 #' @param surv.size point size for survival curve
 #' @param surv.linetype line type for survival curve
 #' @param surv.alpha alpha for survival curve
@@ -152,6 +153,8 @@ fortify.survfit <- function(model, data = NULL, surv.connect = FALSE,
 #'   autoplot(survfit(Surv(time, status) ~ 1, data = lung))
 #'   autoplot(survfit(Surv(time, status) ~ sex, data=lung), conf.int = FALSE, censor = FALSE)
 #'   autoplot(survfit(Surv(time, status) ~ sex, data=lung), surv.colour = 'red')
+#'   autoplot(survfit(Surv(time, status) ~ sex, data=lung),
+#'            surv.colour = c('red', 'blue'))
 #'   autoplot(survfit(coxph(Surv(time, status) ~ sex, data = lung)))
 #' }
 #' }
@@ -173,6 +176,15 @@ autoplot.survfit <- function(object, fun = NULL,
                              xlim = c(NA, NA), ylim = c(NA, NA), log = "",
                              main = NULL, xlab = NULL, ylab = NULL, asp = NULL,
                              ...) {
+
+  # A colour vector represents one palette value per curve group, not one
+  # value per row in the fortified survival data. Keep it separate so the
+  # geometry can map the grouping variable and the scale can apply the colours.
+  surv.palette <- NULL
+  if (length(surv.colour) > 1L) {
+    surv.palette <- surv.colour
+    surv.colour <- NULL
+  }
 
   if (is_derived_from(object, 'aareg')) {
     # for autoplot.aareg, object must be a data.frame
@@ -207,6 +219,10 @@ autoplot.survfit <- function(object, fun = NULL,
       if (is.null(surv.linetype)) {
         surv.linetype <- 'event'
       }
+      # For multistate fits without strata, events identify the curve groups.
+      if (is.null(surv.colour) && !is.null(surv.palette)) {
+        surv.colour <- 'event'
+      }
     }
 
     if (length(group) == 1) {
@@ -237,6 +253,10 @@ autoplot.survfit <- function(object, fun = NULL,
     }
   }
 
+  if (!is.null(surv.palette) && is.null(surv.colour)) {
+    stop("A 'surv.colour' palette requires a grouped survival curve")
+  }
+
   if (missing(conf.int.fill) & !is.null(surv.colour)) {
     conf.int.fill <- surv.colour
   }
@@ -260,6 +280,14 @@ autoplot.survfit <- function(object, fun = NULL,
                     conf.int.colour = conf.int.colour,
                     conf.int.linetype = conf.int.linetype,
                     conf.int.fill = conf.int.fill, conf.int.alpha = conf.int.alpha)
+  # Apply the palette after mappings are established. When confidence fills
+  # use the same grouping variable, keep their colours aligned with the curves.
+  if (!is.null(surv.palette)) {
+    p <- p + ggplot2::scale_colour_manual(values = surv.palette)
+    if (conf.int && identical(conf.int.fill, surv.colour)) {
+      p <- p + ggplot2::scale_fill_manual(values = surv.palette)
+    }
+  }
   if (censor & 'n.censor' %in% colnames(plot.data)) {
     p <- p + geom_factory(geom_point, plot.data[plot.data$n.censor > 0, ],
                           colour = censor.colour, size = censor.size,

--- a/R/fortify_surv.R
+++ b/R/fortify_surv.R
@@ -121,7 +121,9 @@ fortify.survfit <- function(model, data = NULL, surv.connect = FALSE,
 #' @param object \code{survival::survfit} instance
 #' @param fun an arbitrary function defining a transformation of the survival curve
 #' @param surv.geom geometric string for survival curve. 'step', 'line' or 'point'
-#' @param surv.colour line colour for survival curve
+#' @param surv.colour Line colour for the survival curve. A plot-data column
+#'   name maps colour and creates a legend; a colour value sets a fixed colour
+#'   and does not create a legend.
 #' @param surv.size point size for survival curve
 #' @param surv.linetype line type for survival curve
 #' @param surv.alpha alpha for survival curve
@@ -149,6 +151,7 @@ fortify.survfit <- function(model, data = NULL, surv.connect = FALSE,
 #'   autoplot(survfit(Surv(time, status) ~ sex, data = lung), facets = TRUE)
 #'   autoplot(survfit(Surv(time, status) ~ 1, data = lung))
 #'   autoplot(survfit(Surv(time, status) ~ sex, data=lung), conf.int = FALSE, censor = FALSE)
+#'   autoplot(survfit(Surv(time, status) ~ sex, data=lung), surv.colour = 'red')
 #'   autoplot(survfit(coxph(Surv(time, status) ~ sex, data = lung)))
 #' }
 #' }
@@ -243,6 +246,7 @@ autoplot.survfit <- function(object, fun = NULL,
   p <- ggplot(data = plot.data, mapping = mapping) +
     scale_y_continuous(labels = scale_labels)
   p <- p + geom_factory(geomfunc, plot.data,
+                        group = 'group',
                         colour = surv.colour, size = surv.size, linetype = surv.linetype,
                         alpha = surv.alpha, fill = surv.fill, shape = surv.shape)
   if (surv.geom == 'step') {

--- a/man/autoplot.survfit.Rd
+++ b/man/autoplot.survfit.Rd
@@ -49,7 +49,9 @@
 
 \item{surv.geom}{geometric string for survival curve. 'step', 'line' or 'point'}
 
-\item{surv.colour}{line colour for survival curve}
+\item{surv.colour}{Line colour for the survival curve. A plot-data column
+name maps colour and creates a legend; a colour value sets a fixed colour
+and does not create a legend.}
 
 \item{surv.size}{point size for survival curve}
 
@@ -124,6 +126,7 @@ if (requireNamespace("survival", quietly = TRUE)) {
   autoplot(survfit(Surv(time, status) ~ sex, data = lung), facets = TRUE)
   autoplot(survfit(Surv(time, status) ~ 1, data = lung))
   autoplot(survfit(Surv(time, status) ~ sex, data=lung), conf.int = FALSE, censor = FALSE)
+  autoplot(survfit(Surv(time, status) ~ sex, data=lung), surv.colour = 'red')
   autoplot(survfit(coxph(Surv(time, status) ~ sex, data = lung)))
 }
 }

--- a/man/autoplot.survfit.Rd
+++ b/man/autoplot.survfit.Rd
@@ -50,8 +50,9 @@
 \item{surv.geom}{geometric string for survival curve. 'step', 'line' or 'point'}
 
 \item{surv.colour}{Line colour for the survival curve. A plot-data column
-name maps colour and creates a legend; a colour value sets a fixed colour
-and does not create a legend.}
+name maps colour and creates a legend; a single colour value sets a fixed
+colour; and a vector supplies a manual palette for the automatically
+mapped grouping variable.}
 
 \item{surv.size}{point size for survival curve}
 
@@ -127,6 +128,8 @@ if (requireNamespace("survival", quietly = TRUE)) {
   autoplot(survfit(Surv(time, status) ~ 1, data = lung))
   autoplot(survfit(Surv(time, status) ~ sex, data=lung), conf.int = FALSE, censor = FALSE)
   autoplot(survfit(Surv(time, status) ~ sex, data=lung), surv.colour = 'red')
+  autoplot(survfit(Surv(time, status) ~ sex, data=lung),
+           surv.colour = c('red', 'blue'))
   autoplot(survfit(coxph(Surv(time, status) ~ sex, data = lung)))
 }
 }

--- a/tests/testthat/test-surv.R
+++ b/tests/testthat/test-surv.R
@@ -106,6 +106,75 @@ test_that('fixed survival colour preserves strata grouping (#120)', {
   expect_null(p$layers[[1]]$mapping$colour)
 })
 
+test_that('survival colour vectors supply palettes for grouped curves (#120)', {
+  skip_if_not_installed('survival')
+  fit <- survival::survfit(
+    survival::Surv(time, status) ~ sex,
+    data = survival::lung
+  )
+
+  p <- ggplot2::autoplot(fit, surv.colour = c('red', 'blue'))
+  curve <- ggplot2::layer_data(p, 1)
+  interval <- ggplot2::layer_data(p, 2)
+
+  expect_setequal(unique(curve$colour), c('red', 'blue'))
+  expect_setequal(unique(interval$fill), c('red', 'blue'))
+  expect_equal(length(unique(curve$group)), 2L)
+  expect_equal(rlang::as_name(p$layers[[1]]$mapping$colour), 'strata')
+  expect_s3_class(p$scales$get_scales('colour'), 'ScaleDiscrete')
+
+  three.groups <- transform(
+    survival::lung,
+    group = factor(rep(c('first', 'second', 'third'),
+                       length.out = nrow(survival::lung)))
+  )
+  three.fit <- survival::survfit(
+    survival::Surv(time, status) ~ group,
+    data = three.groups
+  )
+  three.palette <- c(first = 'red', second = 'blue', third = 'green')
+  three.plot <- ggplot2::autoplot(
+    three.fit, conf.int = FALSE, surv.colour = three.palette
+  )
+  three.curves <- ggplot2::layer_data(three.plot, 1)
+
+  expect_setequal(unique(three.curves$colour), unname(three.palette))
+  expect_equal(length(unique(three.curves$group)), 3L)
+
+  expect_error(
+    ggplot2::ggplot_build(
+      ggplot2::autoplot(
+        three.fit, surv.colour = c('red', 'blue')
+      )
+    ),
+    'Insufficient values in manual scale'
+  )
+
+  unstratified <- survival::survfit(
+    survival::Surv(time, status) ~ 1,
+    data = survival::lung
+  )
+  expect_error(
+    ggplot2::autoplot(unstratified, surv.colour = c('red', 'blue')),
+    'requires a grouped survival curve'
+  )
+
+  multistate <- survival::survfit(
+    survival::Surv(start, stop, event) ~ 1,
+    id = id,
+    data = survival::mgus1
+  )
+  event.palette <- c('red', 'blue', 'green')
+  event.plot <- ggplot2::autoplot(
+    multistate, conf.int = FALSE, surv.colour = event.palette
+  )
+  event.curves <- ggplot2::layer_data(event.plot, 1)
+
+  expect_equal(rlang::as_name(event.plot$layers[[1]]$mapping$colour), 'event')
+  expect_setequal(unique(event.curves$colour), event.palette)
+  expect_equal(length(unique(event.curves$group)), 3L)
+})
+
 test_that('fortify.survfit works for simple data', {
   skip_if_not_installed("survival")
   library(survival)

--- a/tests/testthat/test-surv.R
+++ b/tests/testthat/test-surv.R
@@ -88,6 +88,24 @@ test_that('autoplot retains order of alphabetically unordered factor levels', {
   expect_equal(levels(plotElements[["data"]][, "strata"]), c("Low", "High"))
 })
 
+test_that('fixed survival colour preserves strata grouping (#120)', {
+  skip_if_not_installed('survival')
+  fit <- survival::survfit(
+    survival::Surv(time, status) ~ sex,
+    data = survival::lung
+  )
+
+  p <- ggplot2::autoplot(
+    fit, conf.int = FALSE, censor = FALSE, surv.colour = 'red'
+  )
+  layer <- ggplot2::layer_data(p, 1)
+
+  expect_equal(length(unique(layer$group)), 2L)
+  expect_equal(p$layers[[1]]$aes_params$colour, 'red')
+  expect_equal(rlang::as_name(p$layers[[1]]$mapping$group), 'group')
+  expect_null(p$layers[[1]]$mapping$colour)
+})
+
 test_that('fortify.survfit works for simple data', {
   skip_if_not_installed("survival")
   library(survival)


### PR DESCRIPTION
Created with the assistance of Codex, GPT-5.6. Manually reviewed and tested.

## Summary

Fixes #120.

`autoplot.survfit()` previously relied on a mapped colour aesthetic to separate survival curves. Setting a fixed colour removed that implicit grouping, causing separate strata to be connected as one curve.

Additionally, passing a colour vector such as:

```r
surv.colour = c("red", "blue")
```

was interpreted as one colour per row of the fortified survival data instead of one colour per curve group.

This change:

- explicitly maps the internal survival group, independently of colour
- preserves separate curves when using a fixed colour
- interprets multi-value `surv.colour` as a manual palette
- maps palettes to `strata`, `variable`, or multistate `event`, as appropriate
- applies the palette with `scale_colour_manual()`
- applies matching confidence-interval fills when applicable
- preserves existing scalar and column-name behaviour
- rejects palettes for ungrouped survival curves

## Examples

```r
library(ggfortify)
library(ggplot2)
library(survival)
```

### 1. Fixed colour preserves separate curves

```r
fit.two <- survfit(
  Surv(time, status) ~ sex,
  data = lung
)

p.fixed <- autoplot(
  fit.two,
  conf.int = FALSE,
  censor = FALSE,
  surv.colour = "red"
) +
  ggtitle("Fixed colour")

fixed.data <- layer_data(p.fixed, 1)

stopifnot(
  length(unique(fixed.data$group)) == 2L,
  identical(p.fixed$layers[[1]]$aes_params$colour, "red"),
  is.null(p.fixed$layers[[1]]$mapping$colour)
)

print(p.fixed)
```
<img width="837" height="507" alt="image" src="https://github.com/user-attachments/assets/ee2f4ae2-ca11-4516-8dc2-e54f2c02bc78" />

Both strata remain separate and are drawn in red. As expected for a fixed aesthetic, no colour legend is created.

### 2. Two-stratum palette with legend

```r
p.two <- autoplot(
  fit.two,
  conf.int = FALSE,
  censor = FALSE,
  surv.colour = c("red", "blue")
) +
  ggtitle("Two-colour palette")

two.data <- layer_data(p.two, 1)

stopifnot(
  setequal(unique(two.data$colour), c("red", "blue")),
  length(unique(two.data$group)) == 2L,
  rlang::as_name(p.two$layers[[1]]$mapping$colour) == "strata"
)

print(p.two)
```
<img width="837" height="507" alt="image" src="https://github.com/user-attachments/assets/a85a2138-fb53-4f80-b0ff-89dda9935baa" />

The palette is mapped to `strata`, producing one red curve, one blue curve, and a legend.

### 3. Matching confidence-interval palette

```r
p.confidence <- autoplot(
  fit.two,
  surv.colour = c("firebrick", "steelblue")
) +
  ggtitle("Matching curves and confidence intervals")

curve.data <- layer_data(p.confidence, 1)
interval.data <- layer_data(p.confidence, 2)

stopifnot(
  setequal(
    unique(curve.data$colour),
    c("firebrick", "steelblue")
  ),
  setequal(
    unique(interval.data$fill),
    c("firebrick", "steelblue")
  )
)

print(p.confidence)
```
<img width="837" height="507" alt="image" src="https://github.com/user-attachments/assets/b02a3664-bc49-4fcf-af10-740e19d561b7" />

When confidence fill is mapped to the same grouping variable, it uses the survival-curve palette.

### 4. Three-stratum named palette

```r
lung.three <- transform(
  lung,
  group = factor(
    rep(
      c("first", "second", "third"),
      length.out = nrow(lung)
    )
  )
)

fit.three <- survfit(
  Surv(time, status) ~ group,
  data = lung.three
)

three.palette <- c(
  first  = "firebrick",
  second = "steelblue",
  third  = "darkgreen"
)

p.three <- autoplot(
  fit.three,
  conf.int = FALSE,
  censor = FALSE,
  surv.colour = three.palette
) +
  ggtitle("Three-stratum palette")

three.data <- layer_data(p.three, 1)

stopifnot(
  setequal(unique(three.data$colour), unname(three.palette)),
  length(unique(three.data$group)) == 3L
)

print(p.three)
```
<img width="837" height="507" alt="image" src="https://github.com/user-attachments/assets/f2679213-0dd1-4ed9-9178-2d69b9bc6136" />

Named palette values follow standard ggplot2 matching behaviour.