### PR TITLE
Support function facet labellers in ggfreqplot

### DIFF
--- a/R/tslib.R
+++ b/R/tslib.R
@@ -339,7 +339,8 @@ ggtsdiag <- function(object, gof.lag = 10,
 #' @param ncol Number of plot columns
 #' @inheritParams plot_confint
 #' @param conf.int.value Coverage probability for confidence interval
-#' @param facet.labeller A vector used as facet labels
+#' @param facet.labeller A function mapping current facet labels to new labels,
+#'   or a vector with the same length as \code{freq} used as facet labels
 #' @param ... Keywords passed to autoplot.ts
 #' @return ggplot
 #' @examples
@@ -347,6 +348,8 @@ ggtsdiag <- function(object, gof.lag = 10,
 #' ggfreqplot(AirPassengers)
 #' ggfreqplot(AirPassengers, freq = 4)
 #' ggfreqplot(AirPassengers, conf.int = TRUE)
+#' ggfreqplot(AirPassengers,
+#'            facet.labeller = function(x) month.abb[as.integer(x)])
 #' }
 #' @export
 ggfreqplot <- function(data, freq = NULL,
@@ -367,12 +370,16 @@ ggfreqplot <- function(data, freq = NULL,
   }
 
   d <- ggplot2::fortify(data)
+  facet.labeller.function <- ggplot2::label_value
   if (is.null(facet.labeller)) {
     freqs <- 1:freq
+  } else if (is.function(facet.labeller)) {
+    freqs <- 1:freq
+    facet.labeller.function <- ggplot2::as_labeller(facet.labeller)
   } else if (length(facet.labeller)  == freq) {
     freqs <- factor(facet.labeller, levels = facet.labeller)
   } else {
-    stop('facet.labeller must be a vector which has the same length as freq')
+    stop('facet.labeller must be a function or a vector with length freq')
   }
   freqd <- data.frame(Frequency = rep(freqs, length.out = length(data)))
   d <- cbind(d, freqd)
@@ -389,7 +396,8 @@ ggfreqplot <- function(data, freq = NULL,
   p <- autoplot.ts(d, columns = 'Data', ...)
   p <- p + ggplot2::geom_line(mapping = ggplot2::aes(y = .data[['m']]),
                        colour = conf.int.colour) +
-    ggplot2::facet_wrap(~Frequency, nrow = nrow, ncol = ncol)
+    ggplot2::facet_wrap(~Frequency, nrow = nrow, ncol = ncol,
+                        labeller = facet.labeller.function)
   p <- plot_confint(p = p, data = d, conf.int = conf.int,
                     conf.int.colour = conf.int.colour,
                     conf.int.linetype = conf.int.linetype,

--- a/man/ggfreqplot.Rd
+++ b/man/ggfreqplot.Rd
@@ -40,7 +40,8 @@ ggfreqplot(
 
 \item{conf.int.value}{Coverage probability for confidence interval}
 
-\item{facet.labeller}{A vector used as facet labels}
+\item{facet.labeller}{A function mapping current facet labels to new labels,
+or a vector with the same length as \code{freq} used as facet labels}
 
 \item{...}{Keywords passed to autoplot.ts}
 }
@@ -55,5 +56,7 @@ Plot seasonal subseries of time series, generalization of \code{stats::monthplot
 ggfreqplot(AirPassengers)
 ggfreqplot(AirPassengers, freq = 4)
 ggfreqplot(AirPassengers, conf.int = TRUE)
+ggfreqplot(AirPassengers,
+           facet.labeller = function(x) month.abb[as.integer(x)])
 }
 }

--- a/tests/testthat/test-tslib.R
+++ b/tests/testthat/test-tslib.R
@@ -91,8 +91,28 @@ test_that('ggfreqplot', {
   p <- ggfreqplot(AirPassengers)
   expect_true(inherits(p, 'ggplot'))
 
-  p <- ggfreqplot(AirPassengers, facet.labeller = c(3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2))
+  facet.labels <- c(3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2)
+  p <- ggfreqplot(AirPassengers, facet.labeller = facet.labels)
   expect_true(inherits(p, 'ggplot'))
+  expect_equal(levels(p$data$Frequency), as.character(facet.labels))
+
+  expect_error(
+    ggfreqplot(AirPassengers, facet.labeller = c('first', 'second')),
+    'must be a function or a vector with length freq'
+  )
+})
+
+test_that('ggfreqplot accepts facet labeller functions (#46)', {
+  skip_if_not_installed('zoo')
+  labels <- data.frame(Frequency = as.character(1:12))
+  attr(labels, 'type') <- 'cols'
+  attr(labels, 'facet') <- 'wrap'
+
+  mapper <- function(x) paste0('period-', x)
+  p <- ggfreqplot(AirPassengers, facet.labeller = mapper)
+  mapped <- p$facet$params$labeller(labels)
+  expect_equal(mapped$Frequency, paste0('period-', 1:12))
+  expect_equal(sort(unique(p$data$Frequency)), 1:12)
 })
 
 


### PR DESCRIPTION
Created with the assistance of Codex, GPT-5.6. Manually reviewed and tested.
## Summary

Follow-up to #46. Closes #47.

`ggfreqplot()` currently accepts a vector of replacement facet labels but does not accept a function that maps existing labels to new labels.

The ggplot2 limitation mentioned in #46 no longer applies: `facet_wrap()` now supports labeller functions, and `as_labeller()` converts a character-vector mapping function into a facet labeller.

This change:

- accepts a function in `facet.labeller`
- adapts it with `ggplot2::as_labeller()`
- passes the resulting labeller to `facet_wrap()`
- leaves the underlying `Frequency` values unchanged when a function is used
- preserves the existing vector-label behavior and facet ordering
- updates the documentation and example

## Tests

### 1. Default labels
```r
p.default <- ggfreqplot(
  AirPassengers,
  ncol = 4
)

print(p.default)
```
Expected facet labels: 1 through 12.
<img width="837" height="507" alt="image" src="https://github.com/user-attachments/assets/517131f6-bac8-40ec-970c-766a083cc4b4" />

### 2. Function mapping numbers to month names
```r
month.labeller <- function(x) {
  month.abb[as.integer(x)]
}

p.months <- ggfreqplot(
  AirPassengers,
  ncol = 4,
  facet.labeller = month.labeller
)

print(p.months)
```
Expected facet labels: Jan through Dec.
<img width="837" height="507" alt="image" src="https://github.com/user-attachments/assets/937a7fab-cd9d-4bf6-aa7d-c9342d786e26" />

### 3. Custom quarterly labels
```r
quarter.labeller <- function(x) {
  paste("Quarter", x)
}

p.quarters <- ggfreqplot(
  AirPassengers,
  freq = 4,
  ncol = 2,
  facet.labeller = quarter.labeller
)

print(p.quarters)
```
Expected labels: Quarter 1 through Quarter 4.
<img width="837" height="507" alt="image" src="https://github.com/user-attachments/assets/d2c649db-4cbf-46fb-955f-2049a6d6ff78" />

### 4. Existing vector behavior remains supported
```r
rotated.labels <- c(
  3, 4, 5, 6, 7, 8,
  9, 10, 11, 12, 1, 2
)

p.vector <- ggfreqplot(
  AirPassengers,
  ncol = 4,
  facet.labeller = rotated.labels
)

print(p.vector)
```
Expected facet order: 3 through 12, followed by 1 and 2.
<img width="837" height="507" alt="image" src="https://github.com/user-attachments/assets/e5c3333f-ece5-44e2-a207-2e406c3f4efe" />
