### PR TITLE
Prepare release 0.4.23

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ggfortify
 Type: Package
 Title: Data Visualization Tools for Statistical Analysis Results
-Version: 0.4.22
-Date: 2026-08-20
+Version: 0.4.23
+Date: 2026-09-03
 Authors@R: c(
   person("Masaaki", "Horikoshi", role = c("aut"),
          email = "sinhrks@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+## ggfortify 0.4.23
+
+* Fixed axis label overrides and added step geometry support in `ggdistribution`.
+* Added support for fixed and per-group colours in survival curves.
+* Added function facet labellers to `ggfreqplot`.
+* Updated tests and tidyselect usage for compatibility with current dependencies.
+
 ## ggfortify 0.4.22
 
 * Updated tests for compatibility with recent dependency behavior.

--- a/R/fortify_surv.R
+++ b/R/fortify_surv.R
@@ -343,7 +343,7 @@ fortify.aareg <- function(model, data = NULL,
     if (surv.connect) {
       d <- rbind(0, d)
     }
-    d <- tidyr::gather(d, 'variable', 'coef', cols)
+    d <- tidyr::gather(d, 'variable', 'coef', dplyr::all_of(cols))
     d <- d %>%
       dplyr::group_by(variable) %>%
       dplyr::mutate(se = sqrt(cumsum(coef ^ 2)),

--- a/tests/testthat/test-surv.R
+++ b/tests/testthat/test-surv.R
@@ -102,7 +102,6 @@ test_that('fixed survival colour preserves strata grouping (#120)', {
 
   expect_equal(length(unique(layer$group)), 2L)
   expect_equal(p$layers[[1]]$aes_params$colour, 'red')
-  expect_equal(rlang::as_name(p$layers[[1]]$mapping$group), 'group')
   expect_null(p$layers[[1]]$mapping$colour)
 })
 
@@ -120,7 +119,6 @@ test_that('survival colour vectors supply palettes for grouped curves (#120)', {
   expect_setequal(unique(curve$colour), c('red', 'blue'))
   expect_setequal(unique(interval$fill), c('red', 'blue'))
   expect_equal(length(unique(curve$group)), 2L)
-  expect_equal(rlang::as_name(p$layers[[1]]$mapping$colour), 'strata')
   expect_s3_class(p$scales$get_scales('colour'), 'ScaleDiscrete')
 
   three.groups <- transform(
@@ -170,7 +168,6 @@ test_that('survival colour vectors supply palettes for grouped curves (#120)', {
   )
   event.curves <- ggplot2::layer_data(event.plot, 1)
 
-  expect_equal(rlang::as_name(event.plot$layers[[1]]$mapping$colour), 'event')
   expect_setequal(unique(event.curves$colour), event.palette)
   expect_equal(length(unique(event.curves$group)), 3L)
 })


### PR DESCRIPTION
## Summary

- Bump the package version from 0.4.22 to 0.4.23.
- Remove direct `rlang::as_name()` calls from survival tests. 
- Wrap the external `cols` vector with `dplyr::all_of()` in `fortify.aareg()` to resolve the tidyselect deprecation warning.