### PR TITLE
Support discrete PMFs in ggdistribution

### DIFF
--- a/R/fortify_stats_density.R
+++ b/R/fortify_stats_density.R
@@ -48,10 +48,20 @@ autoplot.density <- function (object, p = NULL,
     p <- ggplot2::ggplot(mapping = mapping)
   }
   is.discrete <- isTRUE(attr(object, 'ggfortify.discrete_cdf'))
+  is.discrete.pmf <- isTRUE(attr(object, 'ggfortify.discrete_pmf'))
   geomfunc <- if (is.discrete) geom_step else geom_line
   ribbonfunc <- if (is.discrete) geom_confint else geom_ribbon
 
-  if (!is.null(fill)) {
+  if (is.discrete.pmf) {
+    bar.fill <- if (is.null(fill)) colour else fill
+
+    if (!is.null(fill) && is.null(alpha)) {
+      alpha <- 0.3
+    }
+
+    p <- p + geom_factory(geom_col, object, colour = colour,
+                          linetype = linetype, fill = bar.fill, alpha = alpha)
+  } else if (!is.null(fill)) {
 
     if (is.null(alpha)) {
       # specify default which should not affect to geom_line
@@ -79,9 +89,18 @@ is_discrete_cdf <- function(func) {
     any(vapply(discrete_cdfs, identical, logical(1L), y = func))
 }
 
+is_discrete_pmf <- function(func) {
+  discrete_pmfs <- list(
+    stats::dbinom, stats::dgeom, stats::dhyper, stats::dnbinom,
+    stats::dpois, stats::dsignrank, stats::dwilcox
+  )
+
+  any(vapply(discrete_pmfs, identical, logical(1L), y = func))
+}
+
 #' Plot distribution
 #'
-#' @param func PDF or CDF function
+#' @param func PDF, PMF, or CDF function
 #' @param x Numeric vector to be passed to func
 #' @param p \code{ggplot2::ggplot} instance to plot
 #' @param colour Line colour
@@ -99,6 +118,7 @@ is_discrete_cdf <- function(func) {
 #' @return ggplot
 #' @examples
 #' ggdistribution(dnorm, seq(-3, 3, 0.1), mean = 0, sd = 1)
+#' ggdistribution(dpois, 0:30, lambda = 20)
 #' ggdistribution(ppois, seq(0, 30), lambda = 20)
 #'
 #' p <- ggdistribution(pchisq, 0:20, df = 7, fill = 'blue')
@@ -113,6 +133,7 @@ ggdistribution <- function (func, x, p = NULL,
   data <- data.frame(x = x, y = func(x, ...),
                      ymin = rep(0, length(x)))
   attr(data, 'ggfortify.discrete_cdf') <- is_discrete_cdf(func)
+  attr(data, 'ggfortify.discrete_pmf') <- is_discrete_pmf(func)
   p <- autoplot.density(data, p = p, colour = colour, linetype = linetype,
                         fill = fill, alpha = alpha, 
                         xlim = xlim, ylim = ylim, log = log,

--- a/tests/testthat/test-stats-density.R
+++ b/tests/testthat/test-stats-density.R
@@ -24,6 +24,12 @@ test_that('ggdistribution', {
                       fill = 'blue')
   expect_true(is(p$layers[[1]]$geom, 'GeomConfint'))
 
+  p <- ggdistribution(dpois, 0:30, lambda = 20)
+  expect_true(is(p$layers[[1]]$geom, 'GeomBar'))
+
+  p <- ggdistribution(dpois, 0:30, lambda = 20, colour = 'red')
+  expect_equal(p$layers[[1]]$aes_params$fill, 'red')
+
   # repeast
   p <- ggdistribution(pchisq, 0:20, df = 7, fill = 'blue')
   expect_true(is(p, 'ggplot'))
@@ -53,4 +59,12 @@ test_that('standard discrete CDFs are detected', {
   expect_true(ggfortify:::is_discrete_cdf(ecdf(0:3)))
   expect_false(ggfortify:::is_discrete_cdf(pnorm))
   expect_false('geom' %in% names(formals(ggdistribution)))
+})
+
+test_that('standard discrete PMFs are detected', {
+  discrete_pmfs <- list(dbinom, dgeom, dhyper, dnbinom,
+                        dpois, dsignrank, dwilcox)
+  detected <- vapply(discrete_pmfs, ggfortify:::is_discrete_pmf, logical(1L))
+  expect_true(all(detected))
+  expect_false(ggfortify:::is_discrete_pmf(dnorm))
 })


### PR DESCRIPTION
Created with the assistance of Codex, GPT-5.6.
Closes #255 .
## Summary

Add automatic detection and bar geometry for standard base R discrete PMFs in `ggdistribution()`.

- Add `is_discrete_pmf()` for `dbinom`, `dgeom`, `dhyper`, `dnbinom`, `dpois`, `dsignrank`, and `dwilcox`.
- Render detected PMFs with `geom_col()` (`GeomBar`).
- Preserve existing continuous PDF/CDF and discrete CDF behavior.
- Use `colour` as the default PMF bar fill when `fill` is not supplied.
- Document PMF support and add a `dpois()` example.

## Tests
```r
ggdistribution(
  dpois,
  0:30,
  lambda = 20
)
```

<img width="620" height="507" alt="image" src="https://github.com/user-attachments/assets/10e325e2-b262-4696-b5b0-67cac22f05a7" />

```r
ggdistribution(
  dpois,
  0:30,
  lambda = 20,
  colour = "red"
)
```

<img width="620" height="507" alt="image" src="https://github.com/user-attachments/assets/d285a131-f454-4aff-b775-f89df1f91b9d" />
